### PR TITLE
[SPARK-48777][BUILD][FOLLOW] Set version to `v35` since v1 is not allowed and it follows the Spark release.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -20,7 +20,7 @@ proto_library(
 # Create the proto library directly.
 go_proto_library(
     name = "spark_connect_proto",
-    importpath = "github.com/apache/spark-connect-go/v1/internal/generated/spark/connect",
+    importpath = "github.com/apache/spark-connect-go/v35/internal/generated/spark/connect",
     protos = [
         ":spark_connect_protos",
     ],
@@ -30,7 +30,7 @@ go_proto_library(
 go_grpc_library(
     name = "spark_connect_proto_grpc",
     compilers = ["@io_bazel_rules_go//proto:go_grpc"],
-    importpath = "github.com/apache/spark-connect-go/v1/internal/generated/spark/connect",
+    importpath = "github.com/apache/spark-connect-go/v35/internal/generated/spark/connect",
     protos = [
         ":spark_connect_protos",
     ],

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1578,7 +1578,7 @@
       "general": {
         "bzlTransitiveDigest": "sH0ZfrlZyTTSTIpGNBfQJlEWK7fgxR4W5O3QYxF2pqQ=",
         "recordedFileInputs": {
-          "@@//go.mod": "abc5a8099d706c7fbcdeea3162c89e59a155692760627e15fb1b0ad3390ce1b8",
+          "@@//go.mod": "a7d7fa6517fcca894a472a4152e3bc39daf9733f771bf7fc16b01c35e529e642",
           "@@rules_go~//go.mod": "de22304b720f7f61350ec1c9739de6c0a1b1103fd22bfeb6e92c6c843ddc6d6e",
           "@@gazelle~//go.sum": "7c4460e8ecb5dd8691a51d4fa2e9e4751108b933636497ce46db499fc2e7a88d",
           "@@//go.sum": "55323de741b9c6ec4540ada81453c5156c974951335ef4935f6ce3f27e1f0f0c",

--- a/client/channel/BUILD.bazel
+++ b/client/channel/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
         "channel.go",
         "compat.go",
     ],
-    importpath = "github.com/apache/spark-connect-go/v1/client/channel",
+    importpath = "github.com/apache/spark-connect-go/v35/client/channel",
     visibility = ["//visibility:public"],
     deps = [
         "//client/sparkerrors",

--- a/client/channel/channel.go
+++ b/client/channel/channel.go
@@ -27,7 +27,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/apache/spark-connect-go/v1/client/sparkerrors"
+	"github.com/apache/spark-connect-go/v35/client/sparkerrors"
 	"golang.org/x/oauth2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"

--- a/client/channel/channel_test.go
+++ b/client/channel/channel_test.go
@@ -21,8 +21,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/apache/spark-connect-go/v1/client/channel"
-	"github.com/apache/spark-connect-go/v1/client/sparkerrors"
+	"github.com/apache/spark-connect-go/v35/client/channel"
+	"github.com/apache/spark-connect-go/v35/client/sparkerrors"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/client/sparkerrors/BUILD.bazel
+++ b/client/sparkerrors/BUILD.bazel
@@ -3,7 +3,7 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "sparkerrors",
     srcs = ["errors.go"],
-    importpath = "github.com/apache/spark-connect-go/v1/client/sparkerrors",
+    importpath = "github.com/apache/spark-connect-go/v35/client/sparkerrors",
     visibility = ["//visibility:public"],
 )
 

--- a/client/sql/BUILD.bazel
+++ b/client/sql/BUILD.bazel
@@ -13,7 +13,7 @@ go_library(
         "sparksession.go",
         "structtype.go",
     ],
-    importpath = "github.com/apache/spark-connect-go/v1/client/sql",
+    importpath = "github.com/apache/spark-connect-go/v35/client/sql",
     visibility = ["//visibility:public"],
     deps = [
         "//client/channel",

--- a/client/sql/dataframe.go
+++ b/client/sql/dataframe.go
@@ -26,8 +26,8 @@ import (
 	"github.com/apache/arrow/go/v12/arrow"
 	"github.com/apache/arrow/go/v12/arrow/array"
 	"github.com/apache/arrow/go/v12/arrow/ipc"
-	"github.com/apache/spark-connect-go/v1/client/sparkerrors"
-	proto "github.com/apache/spark-connect-go/v1/internal/generated/spark/connect"
+	"github.com/apache/spark-connect-go/v35/client/sparkerrors"
+	proto "github.com/apache/spark-connect-go/v35/internal/generated/spark/connect"
 )
 
 // ResultCollector receives a stream of result rows

--- a/client/sql/dataframe_test.go
+++ b/client/sql/dataframe_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/apache/arrow/go/v12/arrow/float16"
 	"github.com/apache/arrow/go/v12/arrow/ipc"
 	"github.com/apache/arrow/go/v12/arrow/memory"
-	proto "github.com/apache/spark-connect-go/v1/internal/generated/spark/connect"
+	proto "github.com/apache/spark-connect-go/v35/internal/generated/spark/connect"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/client/sql/dataframereader.go
+++ b/client/sql/dataframereader.go
@@ -1,6 +1,6 @@
 package sql
 
-import proto "github.com/apache/spark-connect-go/v1/internal/generated/spark/connect"
+import proto "github.com/apache/spark-connect-go/v35/internal/generated/spark/connect"
 
 // DataFrameReader supports reading data from storage and returning a data frame.
 // TODO needs to implement other methods like Option(), Schema(), and also "strong typed"

--- a/client/sql/dataframewriter.go
+++ b/client/sql/dataframewriter.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/apache/spark-connect-go/v1/client/sparkerrors"
-	proto "github.com/apache/spark-connect-go/v1/internal/generated/spark/connect"
+	"github.com/apache/spark-connect-go/v35/client/sparkerrors"
+	proto "github.com/apache/spark-connect-go/v35/internal/generated/spark/connect"
 )
 
 // DataFrameWriter supports writing data frame to storage.

--- a/client/sql/dataframewriter_test.go
+++ b/client/sql/dataframewriter_test.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"testing"
 
-	proto "github.com/apache/spark-connect-go/v1/internal/generated/spark/connect"
+	proto "github.com/apache/spark-connect-go/v35/internal/generated/spark/connect"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/client/sql/executeplanclient.go
+++ b/client/sql/executeplanclient.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/apache/spark-connect-go/v1/client/sparkerrors"
-	proto "github.com/apache/spark-connect-go/v1/internal/generated/spark/connect"
+	"github.com/apache/spark-connect-go/v35/client/sparkerrors"
+	proto "github.com/apache/spark-connect-go/v35/internal/generated/spark/connect"
 )
 
 type executePlanClient struct {

--- a/client/sql/mocks_test.go
+++ b/client/sql/mocks_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	proto "github.com/apache/spark-connect-go/v1/internal/generated/spark/connect"
+	proto "github.com/apache/spark-connect-go/v35/internal/generated/spark/connect"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"

--- a/client/sql/sparksession.go
+++ b/client/sql/sparksession.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/apache/spark-connect-go/v1/client/channel"
-	"github.com/apache/spark-connect-go/v1/client/sparkerrors"
-	proto "github.com/apache/spark-connect-go/v1/internal/generated/spark/connect"
+	"github.com/apache/spark-connect-go/v35/client/channel"
+	"github.com/apache/spark-connect-go/v35/client/sparkerrors"
+	proto "github.com/apache/spark-connect-go/v35/internal/generated/spark/connect"
 	"github.com/google/uuid"
 	"google.golang.org/grpc/metadata"
 )

--- a/client/sql/sparksession_test.go
+++ b/client/sql/sparksession_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/apache/spark-connect-go/v1/client/sparkerrors"
-	proto "github.com/apache/spark-connect-go/v1/internal/generated/spark/connect"
+	"github.com/apache/spark-connect-go/v35/client/sparkerrors"
+	proto "github.com/apache/spark-connect-go/v35/internal/generated/spark/connect"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/cmd/spark-connect-example-raw-grpc-client/BUILD.bazel
+++ b/cmd/spark-connect-example-raw-grpc-client/BUILD.bazel
@@ -3,7 +3,7 @@ load("@rules_go//go:def.bzl", "go_binary", "go_library")
 go_library(
     name = "spark-connect-example-raw-grpc-client_lib",
     srcs = ["main.go"],
-    importpath = "github.com/apache/spark-connect-go/v1/cmd/spark-connect-example-raw-grpc-client",
+    importpath = "github.com/apache/spark-connect-go/v35/cmd/spark-connect-example-raw-grpc-client",
     visibility = ["//visibility:private"],
     deps = [
         "//:spark_connect_proto_grpc",

--- a/cmd/spark-connect-example-raw-grpc-client/main.go
+++ b/cmd/spark-connect-example-raw-grpc-client/main.go
@@ -22,7 +22,7 @@ import (
 	"log"
 	"time"
 
-	proto "github.com/apache/spark-connect-go/v1/internal/generated/spark/connect"
+	proto "github.com/apache/spark-connect-go/v35/internal/generated/spark/connect"
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"

--- a/cmd/spark-connect-example-spark-session/main.go
+++ b/cmd/spark-connect-example-spark-session/main.go
@@ -21,7 +21,7 @@ import (
 	"flag"
 	"log"
 
-	"github.com/apache/spark-connect-go/v1/client/sql"
+	"github.com/apache/spark-connect-go/v35/client/sql"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module github.com/apache/spark-connect-go/v1
+module github.com/apache/spark-connect-go/v35
 
 go 1.21
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Cleanup from #23 that needs to set the package version to something that is not v1.

### Why are the changes needed?
Go compatibility

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing tests.