### PR TITLE
[SPARK-48777] Set version to v35 as only major versions are allowed in Go

### DIFF
--- a/client/channel/channel.go
+++ b/client/channel/channel.go
@@ -27,7 +27,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/apache/spark-connect-go/v3.5/client/sparkerrors"
+	"github.com/apache/spark-connect-go/v35/client/sparkerrors"
 	"golang.org/x/oauth2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"

--- a/client/channel/channel_test.go
+++ b/client/channel/channel_test.go
@@ -21,8 +21,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/apache/spark-connect-go/v3.5/client/channel"
-	"github.com/apache/spark-connect-go/v3.5/client/sparkerrors"
+	"github.com/apache/spark-connect-go/v35/client/channel"
+	"github.com/apache/spark-connect-go/v35/client/sparkerrors"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/client/sql/dataframe.go
+++ b/client/sql/dataframe.go
@@ -26,8 +26,8 @@ import (
 	"github.com/apache/arrow/go/v12/arrow"
 	"github.com/apache/arrow/go/v12/arrow/array"
 	"github.com/apache/arrow/go/v12/arrow/ipc"
-	"github.com/apache/spark-connect-go/v3.5/client/sparkerrors"
-	proto "github.com/apache/spark-connect-go/v3.5/internal/generated"
+	"github.com/apache/spark-connect-go/v35/client/sparkerrors"
+	proto "github.com/apache/spark-connect-go/v35/internal/generated"
 )
 
 // ResultCollector receives a stream of result rows

--- a/client/sql/dataframe_test.go
+++ b/client/sql/dataframe_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/apache/arrow/go/v12/arrow/float16"
 	"github.com/apache/arrow/go/v12/arrow/ipc"
 	"github.com/apache/arrow/go/v12/arrow/memory"
-	proto "github.com/apache/spark-connect-go/v3.5/internal/generated"
+	proto "github.com/apache/spark-connect-go/v35/internal/generated"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/client/sql/dataframereader.go
+++ b/client/sql/dataframereader.go
@@ -1,6 +1,6 @@
 package sql
 
-import proto "github.com/apache/spark-connect-go/v3.5/internal/generated"
+import proto "github.com/apache/spark-connect-go/v35/internal/generated"
 
 // DataFrameReader supports reading data from storage and returning a data frame.
 // TODO needs to implement other methods like Option(), Schema(), and also "strong typed"

--- a/client/sql/dataframewriter.go
+++ b/client/sql/dataframewriter.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/apache/spark-connect-go/v3.5/client/sparkerrors"
-	proto "github.com/apache/spark-connect-go/v3.5/internal/generated"
+	"github.com/apache/spark-connect-go/v35/client/sparkerrors"
+	proto "github.com/apache/spark-connect-go/v35/internal/generated"
 )
 
 // DataFrameWriter supports writing data frame to storage.

--- a/client/sql/dataframewriter_test.go
+++ b/client/sql/dataframewriter_test.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"testing"
 
-	proto "github.com/apache/spark-connect-go/v3.5/internal/generated"
+	proto "github.com/apache/spark-connect-go/v35/internal/generated"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/client/sql/executeplanclient.go
+++ b/client/sql/executeplanclient.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/apache/spark-connect-go/v3.5/client/sparkerrors"
-	proto "github.com/apache/spark-connect-go/v3.5/internal/generated"
+	"github.com/apache/spark-connect-go/v35/client/sparkerrors"
+	proto "github.com/apache/spark-connect-go/v35/internal/generated"
 )
 
 type executePlanClient struct {

--- a/client/sql/mocks_test.go
+++ b/client/sql/mocks_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	proto "github.com/apache/spark-connect-go/v3.5/internal/generated"
+	proto "github.com/apache/spark-connect-go/v35/internal/generated"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"

--- a/client/sql/sparksession.go
+++ b/client/sql/sparksession.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/apache/spark-connect-go/v3.5/client/channel"
-	"github.com/apache/spark-connect-go/v3.5/client/sparkerrors"
-	proto "github.com/apache/spark-connect-go/v3.5/internal/generated"
+	"github.com/apache/spark-connect-go/v35/client/channel"
+	"github.com/apache/spark-connect-go/v35/client/sparkerrors"
+	proto "github.com/apache/spark-connect-go/v35/internal/generated"
 	"github.com/google/uuid"
 	"google.golang.org/grpc/metadata"
 )

--- a/client/sql/sparksession_test.go
+++ b/client/sql/sparksession_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/apache/spark-connect-go/v3.5/client/sparkerrors"
-	proto "github.com/apache/spark-connect-go/v3.5/internal/generated"
+	"github.com/apache/spark-connect-go/v35/client/sparkerrors"
+	proto "github.com/apache/spark-connect-go/v35/internal/generated"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/cmd/spark-connect-example-raw-grpc-client/main.go
+++ b/cmd/spark-connect-example-raw-grpc-client/main.go
@@ -22,7 +22,7 @@ import (
 	"log"
 	"time"
 
-	proto "github.com/apache/spark-connect-go/v3.5/internal/generated"
+	proto "github.com/apache/spark-connect-go/v35/internal/generated"
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"

--- a/cmd/spark-connect-example-spark-session/main.go
+++ b/cmd/spark-connect-example-spark-session/main.go
@@ -21,7 +21,7 @@ import (
 	"flag"
 	"log"
 
-	"github.com/apache/spark-connect-go/v3.5/client/sql"
+	"github.com/apache/spark-connect-go/v35/client/sql"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module github.com/apache/spark-connect-go/v3.5
+module github.com/apache/spark-connect-go/v35
 
 go 1.21
 

--- a/quick-start.md
+++ b/quick-start.md
@@ -22,7 +22,7 @@ import (
 	"flag"
 	"log"
 
-	"github.com/apache/spark-connect-go/v3.5/client/sql"
+	"github.com/apache/spark-connect-go/v35/client/sql"
 )
 
 var (


### PR DESCRIPTION
### What changes were proposed in this pull request?
The last step from reverting the Bazel migration is to make sure that the module matches the Spark release version.

### Why are the changes needed?
Compatibility

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing tests