### PR TITLE
[SPARK-48754] Refactor Channel builder to support other implementations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ GOFILES_NOVENDOR          := $(shell find . -name vendor -prune -o -type f -name
 GOFILES_BUILD             := $(shell find . -type f -name '*.go' -not -name '*_test.go')
 PROTOFILES                := $(shell find . -name vendor -prune -o -type f -name '*.proto' -print)
 
-ALLGOFILES				  			:= $(shell find . -type f -name '*.go')
+ALLGOFILES				  			:= $(shell find . -type f -name '*.go' -not -name '*.pb.go')
 DATE                      := $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" '+%FT%T%z' 2>/dev/null || date -u '+%FT%T%z')
 
 BUILDFLAGS_NOPIE		  :=

--- a/cmd/spark-connect-example-raw-grpc-client/main.go
+++ b/cmd/spark-connect-example-raw-grpc-client/main.go
@@ -28,9 +28,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-var (
-	remote = flag.String("remote", "localhost:15002", "the remote address of Spark Connect server to connect to")
-)
+var remote = flag.String("remote", "localhost:15002", "the remote address of Spark Connect server to connect to")
 
 func main() {
 	ctx := context.Background()

--- a/cmd/spark-connect-example-spark-session/main.go
+++ b/cmd/spark-connect-example-spark-session/main.go
@@ -19,16 +19,15 @@ package main
 import (
 	"context"
 	"flag"
-	"github.com/apache/spark-connect-go/v35/spark/sql/session"
 	"log"
+
+	"github.com/apache/spark-connect-go/v35/spark/sql/session"
 
 	"github.com/apache/spark-connect-go/v35/spark/sql"
 )
 
-var (
-	remote = flag.String("remote", "sc://localhost:15002",
-		"the remote address of Spark Connect server to connect to")
-)
+var remote = flag.String("remote", "sc://localhost:15002",
+	"the remote address of Spark Connect server to connect to")
 
 func main() {
 	flag.Parse()

--- a/spark/client/channel/channel.go
+++ b/spark/client/channel/channel.go
@@ -40,7 +40,10 @@ import (
 var reservedParams = []string{"user_id", "token", "use_ssl"}
 
 // Builder is the interface that is used to implement different patterns that
-// create the GRPC connection. The main interface method is the Build method.
+// create the GRPC connection.
+//
+// This allows other consumers to plugin custom authentication and authorization
+// handlers without having to extend directly the Spark Connect code.
 type Builder interface {
 	Build(ctx context.Context) (*grpc.ClientConn, error)
 	Headers() map[string]string

--- a/spark/client/channel/channel.go
+++ b/spark/client/channel/channel.go
@@ -125,6 +125,10 @@ func NewBuilder(connection string) (Builder, error) {
 		return nil, err
 	}
 
+	if u.Hostname() == "" {
+		return nil, sparkerrors.WithType(errors.New("URL must contain a hostname"), sparkerrors.InvalidInputError)
+	}
+
 	if u.Scheme != "sc" {
 		return nil, sparkerrors.WithType(errors.New("URL schema must be set to `sc`"), sparkerrors.InvalidInputError)
 	}
@@ -133,10 +137,9 @@ func NewBuilder(connection string) (Builder, error) {
 	host := u.Host
 	// Check if the host part of the URL contains a port and extract.
 	if strings.Contains(u.Host, ":") {
-		hostStr, portStr, err := net.SplitHostPort(u.Host)
-		if err != nil {
-			return nil, err
-		}
+		// We can ignore the error here already since the url parsing
+		// raises the error about invalid port.
+		hostStr, portStr, _ := net.SplitHostPort(u.Host)
 		host = hostStr
 		if len(portStr) != 0 {
 			port, err = strconv.Atoi(portStr)

--- a/spark/client/channel/channel_test.go
+++ b/spark/client/channel/channel_test.go
@@ -38,10 +38,12 @@ func TestBasicChannelBuilder(t *testing.T) {
 
 func TestBasicChannelParsing(t *testing.T) {
 	_, err := channel.NewBuilder("abc://asdada:1333")
-
 	assert.False(t, strings.Contains(err.Error(), "scheme"), "Channel build should fail with wrong scheme")
-	cb, err := channel.NewBuilder("sc://empty")
 
+	_, err = channel.NewBuilder("sc://:1333")
+	assert.False(t, strings.Contains(err.Error(), "scheme"), "Should not have an error for a proper URL")
+
+	cb, err := channel.NewBuilder("sc://empty")
 	assert.Nilf(t, err, "Valid path should not fail: %v", err)
 	assert.Equalf(t, 15002, cb.Port(), "Default port must be set, but got %v", cb.Port)
 

--- a/spark/client/channel/channel_test.go
+++ b/spark/client/channel/channel_test.go
@@ -18,9 +18,10 @@ package channel_test
 
 import (
 	"context"
-	"github.com/apache/spark-connect-go/v35/spark/client/channel"
 	"strings"
 	"testing"
+
+	"github.com/apache/spark-connect-go/v35/spark/client/channel"
 
 	"github.com/apache/spark-connect-go/v35/spark/sparkerrors"
 	"github.com/stretchr/testify/assert"
@@ -42,7 +43,7 @@ func TestBasicChannelParsing(t *testing.T) {
 	cb, err := channel.NewBuilder("sc://empty")
 
 	assert.Nilf(t, err, "Valid path should not fail: %v", err)
-	assert.Equalf(t, 15002, cb.Port, "Default port must be set, but got %v", cb.Port)
+	assert.Equalf(t, 15002, cb.Port(), "Default port must be set, but got %v", cb.Port)
 
 	_, err = channel.NewBuilder("sc://empty:port")
 	assert.NotNilf(t, err, "Port must be a valid integer %v", err)
@@ -55,19 +56,19 @@ func TestBasicChannelParsing(t *testing.T) {
 	assert.ErrorIs(t, err, sparkerrors.InvalidInputError)
 
 	cb, err = channel.NewBuilder(goodChannelURL)
-	assert.Equal(t, "host", cb.Host)
-	assert.Equal(t, 15002, cb.Port)
-	assert.Len(t, cb.Headers, 1)
-	assert.Equal(t, "c", cb.Headers["x-other-header"])
-	assert.Equal(t, "a", cb.User)
-	assert.Equal(t, "b", cb.Token)
+	assert.Equal(t, "host", cb.Host())
+	assert.Equal(t, 15002, cb.Port())
+	assert.Len(t, cb.Headers(), 1)
+	assert.Equal(t, "c", cb.Headers()["x-other-header"])
+	assert.Equal(t, "a", cb.User())
+	assert.Equal(t, "b", cb.Token())
 
 	cb, err = channel.NewBuilder("sc://localhost:443/;token=token;user_id=user_id;cluster_id=a")
 	assert.NoError(t, err)
-	assert.Equal(t, 443, cb.Port)
-	assert.Equal(t, "localhost", cb.Host)
-	assert.Equal(t, "token", cb.Token)
-	assert.Equal(t, "user_id", cb.User)
+	assert.Equal(t, 443, cb.Port())
+	assert.Equal(t, "localhost", cb.Host())
+	assert.Equal(t, "token", cb.Token())
+	assert.Equal(t, "user_id", cb.User())
 }
 
 func TestChannelBuildConnect(t *testing.T) {

--- a/spark/client/channel/compat.go
+++ b/spark/client/channel/compat.go
@@ -1,6 +1,6 @@
 package channel
 
-// ChannelBuilder re-exports Builder as its previous name for compatibility.
+// ChannelBuilder re-exports BaseBuilder as its previous name for compatibility.
 //
-// Deprecated: use Builder instead.
-type ChannelBuilder = Builder
+// Deprecated: use BaseBuilder instead.
+type ChannelBuilder = BaseBuilder

--- a/spark/sql/datatype.go
+++ b/spark/sql/datatype.go
@@ -25,92 +25,79 @@ type DataType interface {
 	TypeName() string
 }
 
-type BooleanType struct {
-}
+type BooleanType struct{}
 
 func (t BooleanType) TypeName() string {
 	return getDataTypeName(t)
 }
 
-type ByteType struct {
-}
+type ByteType struct{}
 
 func (t ByteType) TypeName() string {
 	return getDataTypeName(t)
 }
 
-type ShortType struct {
-}
+type ShortType struct{}
 
 func (t ShortType) TypeName() string {
 	return getDataTypeName(t)
 }
 
-type IntegerType struct {
-}
+type IntegerType struct{}
 
 func (t IntegerType) TypeName() string {
 	return getDataTypeName(t)
 }
 
-type LongType struct {
-}
+type LongType struct{}
 
 func (t LongType) TypeName() string {
 	return getDataTypeName(t)
 }
 
-type FloatType struct {
-}
+type FloatType struct{}
 
 func (t FloatType) TypeName() string {
 	return getDataTypeName(t)
 }
 
-type DoubleType struct {
-}
+type DoubleType struct{}
 
 func (t DoubleType) TypeName() string {
 	return getDataTypeName(t)
 }
 
-type DecimalType struct {
-}
+type DecimalType struct{}
 
 func (t DecimalType) TypeName() string {
 	return getDataTypeName(t)
 }
 
-type StringType struct {
-}
+type StringType struct{}
 
 func (t StringType) TypeName() string {
 	return getDataTypeName(t)
 }
 
-type BinaryType struct {
-}
+type BinaryType struct{}
 
 func (t BinaryType) TypeName() string {
 	return getDataTypeName(t)
 }
 
-type TimestampType struct {
-}
+type TimestampType struct{}
 
 func (t TimestampType) TypeName() string {
 	return getDataTypeName(t)
 }
 
-type TimestampNtzType struct {
-}
+type TimestampNtzType struct{}
 
 func (t TimestampNtzType) TypeName() string {
 	return getDataTypeName(t)
 }
 
-type DateType struct {
-}
+type DateType struct{}
 
 func (t DateType) TypeName() string {
 	return getDataTypeName(t)

--- a/spark/sql/session/sparksession.go
+++ b/spark/sql/session/sparksession.go
@@ -42,6 +42,7 @@ func NewSessionBuilder() *SparkSessionBuilder {
 
 type SparkSessionBuilder struct {
 	connectionString string
+	channelBuilder   channel.Builder
 }
 
 // Remote sets the connection string for remote connection
@@ -50,20 +51,27 @@ func (s *SparkSessionBuilder) Remote(connectionString string) *SparkSessionBuild
 	return s
 }
 
-func (s *SparkSessionBuilder) Build(ctx context.Context) (SparkSession, error) {
-	cb, err := channel.NewBuilder(s.connectionString)
-	if err != nil {
-		return nil, sparkerrors.WithType(fmt.Errorf("failed to connect to remote %s: %w", s.connectionString, err), sparkerrors.ConnectionError)
-	}
+func (s *SparkSessionBuilder) ChannelBuilder(cb channel.Builder) *SparkSessionBuilder {
+	s.channelBuilder = cb
+	return s
+}
 
-	conn, err := cb.Build(ctx)
+func (s *SparkSessionBuilder) Build(ctx context.Context) (SparkSession, error) {
+	if s.channelBuilder == nil {
+		cb, err := channel.NewBuilder(s.connectionString)
+		if err != nil {
+			return nil, sparkerrors.WithType(fmt.Errorf("failed to connect to remote %s: %w", s.connectionString, err), sparkerrors.ConnectionError)
+		}
+		s.channelBuilder = cb
+	}
+	conn, err := s.channelBuilder.Build(ctx)
 	if err != nil {
 		return nil, sparkerrors.WithType(fmt.Errorf("failed to connect to remote %s: %w", s.connectionString, err), sparkerrors.ConnectionError)
 	}
 
 	// Add metadata to the request.
 	meta := metadata.MD{}
-	for k, v := range cb.Headers() {
+	for k, v := range s.channelBuilder.Headers() {
 		meta[k] = append(meta[k], v)
 	}
 

--- a/spark/sql/session/sparksession.go
+++ b/spark/sql/session/sparksession.go
@@ -19,6 +19,7 @@ package session
 import (
 	"context"
 	"fmt"
+
 	"github.com/apache/spark-connect-go/v35/spark/client/channel"
 
 	proto "github.com/apache/spark-connect-go/v35/internal/generated"
@@ -50,7 +51,6 @@ func (s *SparkSessionBuilder) Remote(connectionString string) *SparkSessionBuild
 }
 
 func (s *SparkSessionBuilder) Build(ctx context.Context) (SparkSession, error) {
-
 	cb, err := channel.NewBuilder(s.connectionString)
 	if err != nil {
 		return nil, sparkerrors.WithType(fmt.Errorf("failed to connect to remote %s: %w", s.connectionString, err), sparkerrors.ConnectionError)
@@ -63,7 +63,7 @@ func (s *SparkSessionBuilder) Build(ctx context.Context) (SparkSession, error) {
 
 	// Add metadata to the request.
 	meta := metadata.MD{}
-	for k, v := range cb.Headers {
+	for k, v := range cb.Headers() {
 		meta[k] = append(meta[k], v)
 	}
 

--- a/spark/sql/session/sparksession_test.go
+++ b/spark/sql/session/sparksession_test.go
@@ -151,7 +151,7 @@ func TestSQLCallsExecutePlanWithSQLOnClient(t *testing.T) {
 
 func TestNewSessionBuilderCreatesASession(t *testing.T) {
 	ctx := context.Background()
-	spark, err := NewSessionBuilder().Remote("sc:connection").Build(ctx)
+	spark, err := NewSessionBuilder().Remote("sc://connection").Build(ctx)
 	assert.NoError(t, err)
 	assert.NotNil(t, spark)
 }
@@ -195,22 +195,24 @@ func TestWriteResultStreamsArrowResultToCollector(t *testing.T) {
 
 	session := &sparkSessionImpl{
 		client: &connectServiceClient{
-			executePlanClient: &sql.ExecutePlanClient{&mocks.ProtoClient{
-				RecvResponses: []*proto.ExecutePlanResponse{
-					{
-						ResponseType: &proto.ExecutePlanResponse_SqlCommandResult_{
-							SqlCommandResult: &proto.ExecutePlanResponse_SqlCommandResult{},
+			executePlanClient: &sql.ExecutePlanClient{
+				&mocks.ProtoClient{
+					RecvResponses: []*proto.ExecutePlanResponse{
+						{
+							ResponseType: &proto.ExecutePlanResponse_SqlCommandResult_{
+								SqlCommandResult: &proto.ExecutePlanResponse_SqlCommandResult{},
+							},
 						},
-					},
-					{
-						ResponseType: &proto.ExecutePlanResponse_ArrowBatch_{
-							ArrowBatch: &proto.ExecutePlanResponse_ArrowBatch{
-								RowCount: 1,
-								Data:     buf.Bytes(),
+						{
+							ResponseType: &proto.ExecutePlanResponse_ArrowBatch_{
+								ArrowBatch: &proto.ExecutePlanResponse_ArrowBatch{
+									RowCount: 1,
+									Data:     buf.Bytes(),
+								},
 							},
 						},
 					},
-				}},
+				},
 			},
 			t: t,
 		},


### PR DESCRIPTION
### What changes were proposed in this pull request?
Until now, there could only exist one implementation of a channel builder making it very hard to provide custom implementations of custom authentication and authorization handlers without directly manipulating the Spark Connect code.

This refactoring makes the channel builder an actual interface and allowing consumers to plugin their channel builder during session creation.

```golang
ctx := context.Background()
spark, err := session.NewSessionBuilder().ChannelBuilder(cb).Build(ctx)
```

This will then use the provided channel builder to build the GRPC connection.

### Why are the changes needed?
Compatibility.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing tests.