### PR TITLE
[SPARK-48754] Adding Integration Tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,6 +88,7 @@ jobs:
           # Setup the Environment Variables
           echo "Apache Spark is ready to use"
           echo "SPARK_HOME=${GITHUB_WORKSPACE}/deps/spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }}" >> "$GITHUB_ENV"
+          cd $GITHUB_WORKSPACE
       - name: Run Build & Test
         run: |
           go mod download -x
@@ -97,7 +98,7 @@ jobs:
       - name: Run Integration Test
         run: |
           # make integration
-          echo "Check..."
+          make gen && make && make integration
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,12 +53,29 @@ jobs:
         name: Setup Go
         with:
           go-version-file: 'go.mod'
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: zulu
+
+      - uses: vemonet/setup-spark@v1
+        with:
+          spark-version: '3.5.1'
+          hadoop-version: '3'
+
       - name: Run Build & Test
         run: |
           go mod download -x
           make gen
           make
           make test
+      - name: Run Integration Test
+        run: |
+          make integration
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,10 @@ on:
     branches:
       - master
 
+env:
+  SPARK_VERSION: '3.5.1'
+  HADOOP_VERSION: '3'
+
 permissions:
   # Required: allow read access to the content for analysis.
   contents: read
@@ -62,10 +66,33 @@ jobs:
           java-version: '17'
           distribution: zulu
 
-      - uses: vemonet/setup-spark@v1
+      - name: Cache Spark Installation
+        uses: actions/cache@v2
+        key: spark-${{ SPARK_VERSION }}-bin-hadoop${{ HADOOP_VERSION }}
         with:
-          spark-version: '3.5.1'
-          hadoop-version: '3'
+          path: |
+            ${{ env.GITHUB_WORKSPACE }}/deps/spark-${{ SPARK_VERSION }}-bin-hadoop${{ HADOOP_VERSION }}
+
+      - name: Setup Apache Spark
+        run: |
+          if [ -d ${{ env.GITHUB_WORKSPACE }}/deps/spark-${{ SPARK_VERSION }}-bin-hadoop${{ HADOOP_VERSION }} ]; then
+            echo "Apache Spark is already installed"
+            export SPARK_HOME=${{ env.GITHUB_WORKSPACE }}/../spark-${{ SPARK_VERSION }}-bin-hadoop${{ HADOOP_VERSION }}
+            exit 0
+          fi
+          
+          echo "Apache Spark is not installed"
+          # Access the directory.
+          mkdir -p ${{ env.GITHUB_WORKSPACE }}/deps/
+          cd ${{ env.GITHUB_WORKSPACE }}/deps/
+          wget https://dlcdn.apache.org/spark/spark-${{ SPARK_VERSION }}/spark-${{ SPARK_VERSION }}-bin-hadoop${{ HADOOP_VERSION }}.tgz
+          tar -xzf spark-${{ SPARK_VERSION }}-bin-hadoop${{ HADOOP_VERSION }}.tgz
+          # Delete the old file
+          rm spark-${{ SPARK_VERSION }}-bin-hadoop${{ HADOOP_VERSION }}.tgz
+          
+          # Setup the Environment Variables
+          echo "Apache Spark is ready to use"
+          export SPARK_HOME=${{ env.GITHUB_WORKSPACE }}/deps/spark-${{ SPARK_VERSION }}-bin-hadoop${{ HADOOP_VERSION }}
 
       - name: Run Build & Test
         run: |
@@ -80,3 +107,4 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: v1.59
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,20 +71,20 @@ jobs:
         with:
           key: spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }}
           path: |
-            ${{ env.GITHUB_WORKSPACE }}/deps/spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }}
+            $GITHUB_WORKSPACE/deps/spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }}
 
       - name: Setup Apache Spark
         run: |
-          if [ -d ${{ env.GITHUB_WORKSPACE }}/deps/spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }} ]; then
+          if [ -d $GITHUB_WORKSPACE/deps/spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }} ]; then
             echo "Apache Spark is already installed"
-            export SPARK_HOME=${{ env.GITHUB_WORKSPACE }}/../spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }}
+            export SPARK_HOME=$GITHUB_WORKSPACE/../spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }}
             exit 0
           fi
           
           echo "Apache Spark is not installed"
           # Access the directory.
-          mkdir -p ${{ env.GITHUB_WORKSPACE }}/deps/
-          cd ${{ env.GITHUB_WORKSPACE }}/deps/
+          mkdir -p $GITHUB_WORKSPACE/deps/
+          cd $GITHUB_WORKSPACE/deps/
           wget https://dlcdn.apache.org/spark/spark-${{ env.SPARK_VERSION }}/spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }}.tgz
           tar -xzf spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }}.tgz
           # Delete the old file
@@ -92,7 +92,7 @@ jobs:
           
           # Setup the Environment Variables
           echo "Apache Spark is ready to use"
-          export SPARK_HOME=${{ env.GITHUB_WORKSPACE }}/deps/spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }}
+          export SPARK_HOME=$GITHUB_WORKSPACE/deps/spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }}
 
       - name: Run Build & Test
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,8 @@ jobs:
           make test
       - name: Run Integration Test
         run: |
-          make integration
+          # make integration
+          echo "Check..."
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
           
           # Setup the Environment Variables
           echo "Apache Spark is ready to use"
-          echo "$GITHUB_WORKSPACE/deps/spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }} 
+          echo "$GITHUB_WORKSPACE/deps/spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }}" 
           echo "{SPARK_HOME}={${!GITHUB_WORKSPACE}/deps/spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }}}" >> "$GITHUB_ENV"
       - name: Run Build & Test
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,6 +106,7 @@ jobs:
         with:
           cov_mode: coverage
           main_branch: master
+          cov_threshold: 60
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,8 @@ jobs:
           
           # Setup the Environment Variables
           echo "Apache Spark is ready to use"
-          echo "{SPARK_HOME}={$GITHUB_WORKSPACE/deps/spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }}}" >> "$GITHUB_ENV"
+          echo "$GITHUB_WORKSPACE/deps/spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }} 
+          echo "{SPARK_HOME}={${!GITHUB_WORKSPACE}/deps/spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }}}" >> "$GITHUB_ENV"
       - name: Run Build & Test
         run: |
           go mod download -x

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,26 +74,20 @@ jobs:
             $GITHUB_WORKSPACE/deps/spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }}
 
       - name: Setup Apache Spark
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          if [ -d $GITHUB_WORKSPACE/deps/spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }} ]; then
-            echo "Apache Spark is already installed"
-            export SPARK_HOME=$GITHUB_WORKSPACE/../spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }}
-            exit 0
-          fi
-          
           echo "Apache Spark is not installed"
           # Access the directory.
           mkdir -p $GITHUB_WORKSPACE/deps/
           cd $GITHUB_WORKSPACE/deps/
-          wget https://dlcdn.apache.org/spark/spark-${{ env.SPARK_VERSION }}/spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }}.tgz
+          wget -q https://dlcdn.apache.org/spark/spark-${{ env.SPARK_VERSION }}/spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }}.tgz
           tar -xzf spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }}.tgz
           # Delete the old file
           rm spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }}.tgz
           
           # Setup the Environment Variables
           echo "Apache Spark is ready to use"
-          export SPARK_HOME=$GITHUB_WORKSPACE/deps/spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }}
-
+          echo "{SPARK_HOME}={$GITHUB_WORKSPACE/deps/spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }}}" >> "$GITHUB_ENV"
       - name: Run Build & Test
         run: |
           go mod download -x

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,13 +71,13 @@ jobs:
         key: spark-${{ SPARK_VERSION }}-bin-hadoop${{ HADOOP_VERSION }}
         with:
           path: |
-            ${{ env.GITHUB_WORKSPACE }}/deps/spark-${{ SPARK_VERSION }}-bin-hadoop${{ HADOOP_VERSION }}
+            ${{ env.GITHUB_WORKSPACE }}/deps/spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }}
 
       - name: Setup Apache Spark
         run: |
-          if [ -d ${{ env.GITHUB_WORKSPACE }}/deps/spark-${{ SPARK_VERSION }}-bin-hadoop${{ HADOOP_VERSION }} ]; then
+          if [ -d ${{ env.GITHUB_WORKSPACE }}/deps/spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }} ]; then
             echo "Apache Spark is already installed"
-            export SPARK_HOME=${{ env.GITHUB_WORKSPACE }}/../spark-${{ SPARK_VERSION }}-bin-hadoop${{ HADOOP_VERSION }}
+            export SPARK_HOME=${{ env.GITHUB_WORKSPACE }}/../spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }}
             exit 0
           fi
           
@@ -85,14 +85,14 @@ jobs:
           # Access the directory.
           mkdir -p ${{ env.GITHUB_WORKSPACE }}/deps/
           cd ${{ env.GITHUB_WORKSPACE }}/deps/
-          wget https://dlcdn.apache.org/spark/spark-${{ SPARK_VERSION }}/spark-${{ SPARK_VERSION }}-bin-hadoop${{ HADOOP_VERSION }}.tgz
-          tar -xzf spark-${{ SPARK_VERSION }}-bin-hadoop${{ HADOOP_VERSION }}.tgz
+          wget https://dlcdn.apache.org/spark/spark-${{ env.SPARK_VERSION }}/spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }}.tgz
+          tar -xzf spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }}.tgz
           # Delete the old file
-          rm spark-${{ SPARK_VERSION }}-bin-hadoop${{ HADOOP_VERSION }}.tgz
+          rm spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }}.tgz
           
           # Setup the Environment Variables
           echo "Apache Spark is ready to use"
-          export SPARK_HOME=${{ env.GITHUB_WORKSPACE }}/deps/spark-${{ SPARK_VERSION }}-bin-hadoop${{ HADOOP_VERSION }}
+          export SPARK_HOME=${{ env.GITHUB_WORKSPACE }}/deps/spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }}
 
       - name: Run Build & Test
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Cache Spark Installation
         uses: actions/cache@v2
-        key: spark-${{ SPARK_VERSION }}-bin-hadoop${{ HADOOP_VERSION }}
+        key: spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }}
         with:
           path: |
             ${{ env.GITHUB_WORKSPACE }}/deps/spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,6 +99,13 @@ jobs:
         run: |
           # make integration
           make gen && make && make integration
+      - name: Run Code Coverage
+        run: |
+          make coverage
+      - uses: PaloAltoNetworks/cov@3.0.0
+        with:
+          cov_mode: coverage
+          main_branch: master
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,8 +68,8 @@ jobs:
 
       - name: Cache Spark Installation
         uses: actions/cache@v2
-        key: spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }}
         with:
+          key: spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }}
           path: |
             ${{ env.GITHUB_WORKSPACE }}/deps/spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,8 +87,7 @@ jobs:
           
           # Setup the Environment Variables
           echo "Apache Spark is ready to use"
-          echo "$GITHUB_WORKSPACE/deps/spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }}" 
-          echo "{SPARK_HOME}={${!GITHUB_WORKSPACE}/deps/spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }}}" >> "$GITHUB_ENV"
+          echo "SPARK_HOME=${GITHUB_WORKSPACE}/deps/spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }}" >> "$GITHUB_ENV"
       - name: Run Build & Test
         run: |
           go mod download -x

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ internal/generated.out
 
 # Ignore Coverage Files
 coverage*
+cov.report
 
 # Ignore IDE files
 .idea/

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ cmd/spark-connect-example-spark-session/spark-connect-example-spark-session
 
 target
 lib
+
+deps

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,28 @@ This requires the following tools to be present in your PATH:
 2. `gofumpt` for formatting Go code
 3. `golangci-lint` for linting Go code
 
+### Running Tests
+
+To run the tests locally, you can run:
+
+```bash
+make test
+```
+
+This will run the unit tests. If you want to run the integration tests, you can run:
+
+```bash
+make integration
+```
+
+Lastly, if you want to run all tests and generate the coverage analysis, you can run:
+
+```bash
+make fulltest
+```
+
+The output of the coverage analysis will be in the `coverage.out` file. An HTML version of
+the coverage report is generated and accessible at `coverage.html`.
 
 ### How to write tests
 

--- a/Makefile
+++ b/Makefile
@@ -92,10 +92,10 @@ test: $(BUILD_OUTPUT)
 	    @echo -n "     ";\
 		$(GO) test -v -run '(Test|Example)' $(BUILDFLAGS) $(TESTFLAGS) $(pkg) || exit 1)
 
-fulltest: $(BUILD_OUTPUT)
+coverage: $(BUILD_OUTPUT)
 	@echo ">> TEST, \"coverage\""
 	@$(GO) test -cover -coverprofile=coverage.out -covermode=atomic -coverpkg=./spark/...,./internal/tests/... ./spark/... ./internal/tests/...
-	@$(GO) tool cover -html=coverage.out -o coverage-all.html
+	@$(GO) tool cover -html=coverage.out -o coverage.html
 
 integration: $(BUILD_OUTPUT)
 	@echo ">> TEST, \"integration\""

--- a/Makefile
+++ b/Makefile
@@ -94,12 +94,12 @@ test: $(BUILD_OUTPUT)
 
 fulltest: $(BUILD_OUTPUT)
 	@echo ">> TEST, \"coverage\""
-	@echo "mode: atomic" > coverage-all.out
-	@$(foreach pkg, $(PKGS),\
-	    echo -n "     ";\
-		go test -run '(Test|Example)' $(BUILDFLAGS) $(TESTFLAGS) -coverprofile=coverage.out -covermode=atomic $(pkg) || exit 1;\
-		tail -n +2 coverage.out >> coverage-all.out;)
-	@$(GO) tool cover -html=coverage-all.out -o coverage-all.html
+	@$(GO) test -cover -coverprofile=coverage.out -covermode=atomic -coverpkg=./spark/...,./internal/tests/... ./spark/... ./internal/tests/...
+	@$(GO) tool cover -html=coverage.out -o coverage-all.html
+
+integration: $(BUILD_OUTPUT)
+	@echo ">> TEST, \"integration\""
+	@$(GO) test ./internal/tests/...
 
 check:
 	@echo -n ">> CHECK"

--- a/internal/tests/integration/spark_runner.go
+++ b/internal/tests/integration/spark_runner.go
@@ -42,7 +42,7 @@ func StartSparkConnect() (int64, error) {
 		return -1, sparkerrors.WithType(sparkerrors.TestSetupError, err)
 	}
 
-	timeout := time.After(180 * time.Second)
+	timeout := time.After(60 * time.Second)
 	tick := time.NewTicker(1 * time.Second)
 
 	for {

--- a/internal/tests/integration/spark_runner.go
+++ b/internal/tests/integration/spark_runner.go
@@ -16,11 +16,12 @@
 package integration
 
 import (
-	"github.com/apache/spark-connect-go/v35/spark/sparkerrors"
 	"net"
 	"os"
 	"os/exec"
 	"time"
+
+	"github.com/apache/spark-connect-go/v35/spark/sparkerrors"
 )
 
 func StartSparkConnect() (int64, error) {
@@ -29,7 +30,8 @@ func StartSparkConnect() (int64, error) {
 		return -1, sparkerrors.WithString(sparkerrors.TestSetupError, "SPARK_HOME not set")
 	}
 
-	cmd := exec.Command("./sbin/start-connect-server.sh", "--wait", "--conf", "spark.log.structuredLogging.enabled=false")
+	cmd := exec.Command("./sbin/start-connect-server.sh", "--wait", "--conf",
+		"spark.log.structuredLogging.enabled=false")
 	cmd.Dir = sparkHome
 
 	err := cmd.Start()
@@ -38,13 +40,14 @@ func StartSparkConnect() (int64, error) {
 	}
 
 	timeout := time.After(60 * time.Second)
-	tick := time.Tick(1 * time.Second)
+	tick := time.NewTicker(1 * time.Second)
 
 	for {
 		select {
 		case <-timeout:
-			return -1, sparkerrors.WithString(sparkerrors.TestSetupError, "timeout waiting for Spark Connect to start")
-		case <-tick:
+			return -1, sparkerrors.WithString(sparkerrors.TestSetupError,
+				"timeout waiting for Spark Connect to start")
+		case <-tick.C:
 			if cmd.ProcessState != nil && cmd.ProcessState.Exited() {
 				return -1, sparkerrors.WithString(sparkerrors.TestSetupError, "Spark Connect exited")
 			}

--- a/internal/tests/integration/spark_runner.go
+++ b/internal/tests/integration/spark_runner.go
@@ -16,6 +16,7 @@
 package integration
 
 import (
+	"fmt"
 	"net"
 	"os"
 	"os/exec"
@@ -29,6 +30,8 @@ func StartSparkConnect() (int64, error) {
 	if sparkHome == "" {
 		return -1, sparkerrors.WithString(sparkerrors.TestSetupError, "SPARK_HOME not set")
 	}
+
+	fmt.Printf("Starting Spark Connect Server in: %v\n", os.Getenv("SPARK_HOME"))
 
 	cmd := exec.Command("./sbin/start-connect-server.sh", "--wait", "--conf",
 		"spark.log.structuredLogging.enabled=false")

--- a/internal/tests/integration/spark_runner.go
+++ b/internal/tests/integration/spark_runner.go
@@ -48,6 +48,8 @@ func StartSparkConnect() (int64, error) {
 	for {
 		select {
 		case <-timeout:
+			out, _ := cmd.Output()
+			fmt.Printf("Output: %v\n", string(out))
 			return -1, sparkerrors.WithString(sparkerrors.TestSetupError,
 				"timeout waiting for Spark Connect to start")
 		case <-tick.C:

--- a/internal/tests/integration/spark_runner.go
+++ b/internal/tests/integration/spark_runner.go
@@ -42,7 +42,7 @@ func StartSparkConnect() (int64, error) {
 		return -1, sparkerrors.WithType(sparkerrors.TestSetupError, err)
 	}
 
-	timeout := time.After(60 * time.Second)
+	timeout := time.After(180 * time.Second)
 	tick := time.NewTicker(1 * time.Second)
 
 	for {

--- a/internal/tests/integration/spark_runner.go
+++ b/internal/tests/integration/spark_runner.go
@@ -1,0 +1,62 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"github.com/apache/spark-connect-go/v35/spark/sparkerrors"
+	"net"
+	"os"
+	"os/exec"
+	"time"
+)
+
+func StartSparkConnect() (int64, error) {
+	sparkHome := os.Getenv("SPARK_HOME")
+	if sparkHome == "" {
+		return -1, sparkerrors.WithString(sparkerrors.TestSetupError, "SPARK_HOME not set")
+	}
+
+	cmd := exec.Command("./sbin/start-connect-server.sh", "--wait", "--conf", "spark.log.structuredLogging.enabled=false")
+	cmd.Dir = sparkHome
+
+	err := cmd.Start()
+	if err != nil {
+		return -1, sparkerrors.WithType(sparkerrors.TestSetupError, err)
+	}
+
+	timeout := time.After(60 * time.Second)
+	tick := time.Tick(1 * time.Second)
+
+	for {
+		select {
+		case <-timeout:
+			return -1, sparkerrors.WithString(sparkerrors.TestSetupError, "timeout waiting for Spark Connect to start")
+		case <-tick:
+			if cmd.ProcessState != nil && cmd.ProcessState.Exited() {
+				return -1, sparkerrors.WithString(sparkerrors.TestSetupError, "Spark Connect exited")
+			}
+			conn, err := net.Dial("tcp", "localhost:15002")
+			if err == nil {
+				conn.Close()
+				return int64(cmd.Process.Pid), nil
+			}
+		}
+	}
+}
+
+func StopSparkConnect(pid int64) error {
+	return nil
+}

--- a/internal/tests/integration/spark_runner.go
+++ b/internal/tests/integration/spark_runner.go
@@ -35,7 +35,8 @@ func StartSparkConnect() (int64, error) {
 	fmt.Printf("Starting Spark Connect Server in: %v\n", os.Getenv("SPARK_HOME"))
 
 	cmd := exec.Command("./sbin/start-connect-server.sh", "--wait", "--conf",
-		"spark.log.structuredLogging.enabled=false")
+		"spark.log.structuredLogging.enabled=false", "--packages",
+		"org.apache.spark:spark-connect_2.12:3.5.1")
 	cmd.Dir = sparkHome
 
 	stdout, _ := cmd.StdoutPipe()

--- a/internal/tests/integration/spark_runner.go
+++ b/internal/tests/integration/spark_runner.go
@@ -44,7 +44,7 @@ func StartSparkConnect() (int64, error) {
 		return -1, sparkerrors.WithType(sparkerrors.TestSetupError, err)
 	}
 
-	timeout := time.After(1 * time.Second)
+	timeout := time.After(60 * time.Second)
 	tick := time.NewTicker(1 * time.Second)
 
 	for {

--- a/internal/tests/integration/sql_test.go
+++ b/internal/tests/integration/sql_test.go
@@ -1,0 +1,61 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"context"
+	"github.com/apache/spark-connect-go/v35/spark/sql"
+	"github.com/apache/spark-connect-go/v35/spark/sql/functions"
+	"github.com/stretchr/testify/assert"
+	"log"
+	"os"
+	"testing"
+)
+
+func TestIntegration_RunSQLCommand(t *testing.T) {
+	// Run SQL command
+	ctx := context.Background()
+	spark, err := sql.NewSessionBuilder().Remote("sc://localhost").Build(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	df, err := spark.Sql(ctx, "select * from range(100)")
+	assert.NoError(t, err)
+	res, err := df.Collect(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, 100, len(res))
+
+	col, err := df.Col("id")
+	assert.NoError(t, err)
+	df, err = df.Filter(col.Lt(functions.Lit(10)))
+	assert.NoError(t, err)
+	res, err = df.Collect(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, 10, len(res))
+}
+
+func TestMain(m *testing.M) {
+	pid, err := StartSparkConnect()
+	if err != nil {
+		log.Fatal(err)
+	}
+	code := m.Run()
+	if err = StopSparkConnect(pid); err != nil {
+		log.Fatal(err)
+	}
+	os.Exit(code)
+}

--- a/internal/tests/integration/sql_test.go
+++ b/internal/tests/integration/sql_test.go
@@ -44,7 +44,7 @@ func TestIntegration_RunSQLCommand(t *testing.T) {
 	df, err = df.Filter(col.Lt(functions.Lit(10)))
 	assert.NoError(t, err)
 	res, err = df.Collect(ctx)
-	assert.NoError(t, err)
+	assert.NoErrorf(t, err, "Must be able to collect the rows.")
 	assert.Equal(t, 10, len(res))
 }
 

--- a/internal/tests/integration/sql_test.go
+++ b/internal/tests/integration/sql_test.go
@@ -17,12 +17,13 @@ package integration
 
 import (
 	"context"
-	"github.com/apache/spark-connect-go/v35/spark/sql"
-	"github.com/apache/spark-connect-go/v35/spark/sql/functions"
-	"github.com/stretchr/testify/assert"
 	"log"
 	"os"
 	"testing"
+
+	"github.com/apache/spark-connect-go/v35/spark/sql"
+	"github.com/apache/spark-connect-go/v35/spark/sql/functions"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestIntegration_RunSQLCommand(t *testing.T) {

--- a/spark/client/channel/channel.go
+++ b/spark/client/channel/channel.go
@@ -112,7 +112,8 @@ func (cb *BaseBuilder) Build(ctx context.Context) (*grpc.ClientConn, error) {
 	remote := fmt.Sprintf("%v:%v", cb.host, cb.port)
 	conn, err := grpc.NewClient(remote, opts...)
 	if err != nil {
-		return nil, sparkerrors.WithType(fmt.Errorf("failed to connect to remote %s: %w", remote, err), sparkerrors.ConnectionError)
+		return nil, sparkerrors.WithType(fmt.Errorf("failed to connect to remote %s: %w",
+			remote, err), sparkerrors.ConnectionError)
 	}
 	return conn, nil
 }

--- a/spark/sparkerrors/errors.go
+++ b/spark/sparkerrors/errors.go
@@ -44,6 +44,10 @@ func WithType(err error, errType errorType) error {
 	return &wrappedError{cause: err, errorType: errType}
 }
 
+func WithString(err error, errMsg string) error {
+	return &wrappedError{cause: err, errorType: errors.New(errMsg)}
+}
+
 type errorType error
 
 var (
@@ -54,6 +58,7 @@ var (
 	InvalidPlanError              = errorType(errors.New("invalid plan"))
 	RetriesExceeded               = errorType(errors.New("retries exceeded"))
 	InvalidServerSideSessionError = errorType(errors.New("invalid server side session"))
+	TestSetupError                = errorType(errors.New("test setup error"))
 )
 
 type UnsupportedResponseTypeError struct {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This patch adds a new integration test target that allows running Spark Connect Go integration tests against a locally running Spark version. This makes sure that the project is not only setting up the mocks correctly, but works against a real Spark cluster.

In addition, this PR modifies the build and test workflow to:

* Run the integration tests.
* Calculate the code coverage across unit and integration test.
* Fail the PR if the code coverage is < 60%. This value can be changed later on when the overall coverage increases.

### Why are the changes needed?
Compatibility.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Integration using GH Actions.
