### PR TITLE
Add Agg function an expression literals

### DIFF
--- a/spark/sql/expression/expression.go
+++ b/spark/sql/expression/expression.go
@@ -1,0 +1,22 @@
+package expression
+
+import (
+	proto "github.com/apache/spark-connect-go/v35/internal/generated"
+	"github.com/apache/spark-connect-go/v35/spark/sql/literal"
+)
+
+func Literal(value literal.Value) *proto.Expression {
+	return &proto.Expression{
+		ExprType: &proto.Expression_Literal_{
+			Literal: value.ToPBLiteral(),
+		},
+	}
+}
+
+func Of(literals ...literal.Value) []*proto.Expression {
+	expressions := make([]*proto.Expression, len(literals))
+	for i, l := range literals {
+		expressions[i] = Literal(l)
+	}
+	return expressions
+}

--- a/spark/sql/expression/expression_test.go
+++ b/spark/sql/expression/expression_test.go
@@ -1,0 +1,34 @@
+package expression
+
+import (
+	"testing"
+
+	"github.com/apache/spark-connect-go/v35/spark/sql/literal"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLiteral(t *testing.T) {
+	l := Literal(literal.String("test"))
+	assert.Equal(t, "test", l.GetLiteral().GetString_())
+}
+
+func TestOf(t *testing.T) {
+	literals := []literal.Value{
+		literal.String("test"),
+		literal.Null(0),
+		literal.Binary([]byte("test")),
+		literal.Boolean(true),
+		literal.Byte(1),
+		literal.Short(1),
+		literal.Integer(1),
+		literal.Long(1),
+		literal.Float(1.0),
+		literal.Double(1.0),
+	}
+
+	expressions := Of(literals...)
+	assert.Len(t, expressions, len(literals))
+	for i, l := range literals {
+		assert.Equal(t, l.ToPBLiteral(), expressions[i].GetLiteral())
+	}
+}

--- a/spark/sql/literal/literal.go
+++ b/spark/sql/literal/literal.go
@@ -1,0 +1,211 @@
+package literal
+
+import (
+	"time"
+
+	proto "github.com/apache/spark-connect-go/v35/internal/generated"
+)
+
+type Value interface {
+	ToPBLiteral() *proto.Expression_Literal
+}
+
+type String string
+
+func (s String) ToPBLiteral() *proto.Expression_Literal {
+	return &proto.Expression_Literal{
+		LiteralType: &proto.Expression_Literal_String_{
+			String_: string(s),
+		},
+	}
+}
+
+type Null byte
+
+func (n Null) ToPBLiteral() *proto.Expression_Literal {
+	return &proto.Expression_Literal{
+		LiteralType: &proto.Expression_Literal_Null{},
+	}
+}
+
+type Binary []byte
+
+func (b Binary) ToPBLiteral() *proto.Expression_Literal {
+	return &proto.Expression_Literal{
+		LiteralType: &proto.Expression_Literal_Binary{
+			Binary: b,
+		},
+	}
+}
+
+type Boolean bool
+
+func (b Boolean) ToPBLiteral() *proto.Expression_Literal {
+	return &proto.Expression_Literal{
+		LiteralType: &proto.Expression_Literal_Boolean{
+			Boolean: bool(b),
+		},
+	}
+}
+
+type Byte byte
+
+func (b Byte) ToPBLiteral() *proto.Expression_Literal {
+	return &proto.Expression_Literal{
+		LiteralType: &proto.Expression_Literal_Byte{
+			Byte: int32(b), // Why is the pb type defined to be int32?
+		},
+	}
+}
+
+type Short int16
+
+func (s Short) ToPBLiteral() *proto.Expression_Literal {
+	return &proto.Expression_Literal{
+		LiteralType: &proto.Expression_Literal_Short{
+			Short: int32(s),
+		},
+	}
+}
+
+type Integer int32
+
+func (i Integer) ToPBLiteral() *proto.Expression_Literal {
+	return &proto.Expression_Literal{
+		LiteralType: &proto.Expression_Literal_Integer{
+			Integer: int32(i),
+		},
+	}
+}
+
+type Long int64
+
+func (l Long) ToPBLiteral() *proto.Expression_Literal {
+	return &proto.Expression_Literal{
+		LiteralType: &proto.Expression_Literal_Long{
+			Long: int64(l),
+		},
+	}
+}
+
+type Float float32
+
+func (f Float) ToPBLiteral() *proto.Expression_Literal {
+	return &proto.Expression_Literal{
+		LiteralType: &proto.Expression_Literal_Float{
+			Float: float32(f),
+		},
+	}
+}
+
+type Double float64
+
+func (d Double) ToPBLiteral() *proto.Expression_Literal {
+	return &proto.Expression_Literal{
+		LiteralType: &proto.Expression_Literal_Double{
+			Double: float64(d),
+		},
+	}
+}
+
+func Decimal(value string, precision int32, scale int32) Decimal_ {
+	return Decimal_{
+		Expression_Literal_Decimal: &proto.Expression_Literal_Decimal{
+			Value:     value,
+			Precision: &precision,
+			Scale:     &scale,
+		},
+	}
+}
+
+type Decimal_ struct {
+	*proto.Expression_Literal_Decimal
+}
+
+func (d *Decimal_) ToPBLiteral() *proto.Expression_Literal {
+	return &proto.Expression_Literal{
+		LiteralType: &proto.Expression_Literal_Decimal_{
+			Decimal: d.Expression_Literal_Decimal,
+		},
+	}
+}
+
+func NewDate(date time.Time) Date {
+	inputUtc := date.UTC()
+	epochUtc := time.Unix(0, 0).UTC()
+	return Date(inputUtc.Sub(epochUtc).Hours() / 24) // Going with with description in the protobuf file
+}
+
+type Date int32
+
+func (d Date) ToPBLiteral() *proto.Expression_Literal {
+	return &proto.Expression_Literal{
+		LiteralType: &proto.Expression_Literal_Date{
+			Date: int32(d),
+		},
+	}
+}
+
+type Timestamp time.Time
+
+func (t Timestamp) ToPBLiteral() *proto.Expression_Literal {
+	return &proto.Expression_Literal{
+		LiteralType: &proto.Expression_Literal_Timestamp{
+			Timestamp: time.Time(t).Unix(),
+		},
+	}
+}
+
+type TimestampNtz time.Time
+
+func (t TimestampNtz) ToPBLiteral() *proto.Expression_Literal {
+	return &proto.Expression_Literal{
+		LiteralType: &proto.Expression_Literal_TimestampNtz{
+			TimestampNtz: time.Time(t).Unix(),
+		},
+	}
+}
+
+func CalendarInterval(months int32, days int32, microseconds int64) CalendarInterval_ {
+	return CalendarInterval_{
+		Expression_Literal_CalendarInterval: &proto.Expression_Literal_CalendarInterval{
+			Months:       months,
+			Days:         days,
+			Microseconds: microseconds,
+		},
+	}
+}
+
+type CalendarInterval_ struct {
+	*proto.Expression_Literal_CalendarInterval
+}
+
+func (c CalendarInterval_) ToPBLiteral() *proto.Expression_Literal {
+	return &proto.Expression_Literal{
+		LiteralType: &proto.Expression_Literal_CalendarInterval_{
+			CalendarInterval: c.Expression_Literal_CalendarInterval,
+		},
+	}
+}
+
+type YearMonthInterval int32
+
+func (y YearMonthInterval) ToPBLiteral() *proto.Expression_Literal {
+	return &proto.Expression_Literal{
+		LiteralType: &proto.Expression_Literal_YearMonthInterval{
+			YearMonthInterval: int32(y),
+		},
+	}
+}
+
+type DayTimeInterval int64
+
+func (d DayTimeInterval) ToPBLiteral() *proto.Expression_Literal {
+	return &proto.Expression_Literal{
+		LiteralType: &proto.Expression_Literal_DayTimeInterval{
+			DayTimeInterval: int64(d),
+		},
+	}
+}
+
+// TODO: Missing Array, Map, Struct. Need to think about the exact API for these.

--- a/spark/sql/literal/literal_test.go
+++ b/spark/sql/literal/literal_test.go
@@ -1,0 +1,99 @@
+package literal
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestString_ToPBLiteral(t *testing.T) {
+	s := String("test")
+	assert.Equal(t, "test", s.ToPBLiteral().GetString_())
+}
+
+func TestNull_ToPBLiteral(t *testing.T) {
+	n := Null(0)
+	assert.NotNil(t, n.ToPBLiteral())
+}
+
+func TestBinary_ToPBLiteral(t *testing.T) {
+	b := Binary([]byte("test"))
+	assert.Equal(t, []byte("test"), b.ToPBLiteral().GetBinary())
+}
+
+func TestBoolean_ToPBLiteral(t *testing.T) {
+	b := Boolean(true)
+	assert.Equal(t, true, b.ToPBLiteral().GetBoolean())
+}
+
+func TestByte_ToPBLiteral(t *testing.T) {
+	b := Byte(1)
+	assert.Equal(t, int32(1), b.ToPBLiteral().GetByte())
+}
+
+func TestShort_ToPBLiteral(t *testing.T) {
+	s := Short(1)
+	assert.Equal(t, int32(1), s.ToPBLiteral().GetShort())
+}
+
+func TestInteger_ToPBLiteral(t *testing.T) {
+	i := Integer(1)
+	assert.Equal(t, int32(1), i.ToPBLiteral().GetInteger())
+}
+
+func TestLong_ToPBLiteral(t *testing.T) {
+	l := Long(1)
+	assert.Equal(t, int64(1), l.ToPBLiteral().GetLong())
+}
+
+func TestFloat_ToPBLiteral(t *testing.T) {
+	f := Float(1.0)
+	assert.Equal(t, float32(1.0), f.ToPBLiteral().GetFloat())
+}
+
+func TestDouble_ToPBLiteral(t *testing.T) {
+	d := Double(1.0)
+	assert.Equal(t, float64(1.0), d.ToPBLiteral().GetDouble())
+}
+
+func TestDecimal_ToPBLiteral(t *testing.T) {
+	d := Decimal("1.0", 10, 0)
+	assert.Equal(t, "1.0", d.ToPBLiteral().GetDecimal().GetValue())
+	assert.Equal(t, int32(10), d.ToPBLiteral().GetDecimal().GetPrecision())
+	assert.Equal(t, int32(0), d.ToPBLiteral().GetDecimal().GetScale())
+}
+
+func TestDate_ToPBLiteral(t *testing.T) {
+	d := Date(1)
+	assert.Equal(t, int32(1), d.ToPBLiteral().GetDate())
+}
+
+func TestTimestamp_ToPBLiteral(t *testing.T) {
+	now := time.Now()
+	stamp := Timestamp(now)
+	assert.Equal(t, now.Unix(), stamp.ToPBLiteral().GetTimestamp())
+}
+
+func TestTimestampNtz_ToPBLiteral(t *testing.T) {
+	now := time.Now()
+	stamp := TimestampNtz(now)
+	assert.Equal(t, now.Unix(), stamp.ToPBLiteral().GetTimestampNtz())
+}
+
+func TestCalendarInterval_ToPBLiteral(t *testing.T) {
+	ci := CalendarInterval(1, 2, 3)
+	assert.Equal(t, int32(1), ci.ToPBLiteral().GetCalendarInterval().GetMonths())
+	assert.Equal(t, int32(2), ci.ToPBLiteral().GetCalendarInterval().GetDays())
+	assert.Equal(t, int64(3), ci.ToPBLiteral().GetCalendarInterval().GetMicroseconds())
+}
+
+func TestYearMonthInterval_ToPBLiteral(t *testing.T) {
+	ymi := YearMonthInterval(1)
+	assert.Equal(t, int32(1), ymi.ToPBLiteral().GetYearMonthInterval())
+}
+
+func TestDayTimeInterval_ToPBLiteral(t *testing.T) {
+	dti := DayTimeInterval(1)
+	assert.Equal(t, int64(1), dti.ToPBLiteral().GetDayTimeInterval())
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This PR adds support for the Agg function as well as simple support for expression literals.

This is an initial addition to support https://github.com/apache/spark-connect-go/issues/58

### Why are the changes needed?
This API is not currently support


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Unit tests added