### PR TITLE
[#63] Add stack trace support to spark errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 
 require (
 	cloud.google.com/go/compute/metadata v0.4.0 // indirect
+	github.com/go-errors/errors v1.5.1 // indirect
 	github.com/kr/pretty v0.3.0 // indirect
 	golang.org/x/exp v0.0.0-20240222234643-814bf88cf225 // indirect
 	golang.org/x/sync v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/apache/arrow/go/v17 v17.0.0/go.mod h1:jR7QHkODl15PfYyjM2nU+yTLScZ/qfj
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-errors/errors v1.5.1 h1:ZwEMSLRCapFLflTpT7NKaAc7ukJ8ZPEjzlxt8rPN8bk=
+github.com/go-errors/errors v1.5.1/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/goccy/go-json v0.10.3 h1:KZ5WoDbxAIgm2HNbYckL0se1fHD6rz5j4ywS6ebzDqA=
 github.com/goccy/go-json v0.10.3/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/google/flatbuffers v24.3.25+incompatible h1:CX395cjN9Kke9mmalRoL3d81AtFUxJM+yDthflgJGkI=

--- a/spark/sparkerrors/errors_test.go
+++ b/spark/sparkerrors/errors_test.go
@@ -16,6 +16,7 @@
 package sparkerrors
 
 import (
+	"fmt"
 	"testing"
 
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
@@ -47,6 +48,13 @@ func TestNonGRPCErrorsAreConvertedAsWell(t *testing.T) {
 	se := FromRPCError(err)
 	assert.Equal(t, se.Code, codes.Unknown)
 	assert.Equal(t, se.Message, assert.AnError.Error())
+}
+
+func TestStackTracePrint(t *testing.T) {
+	err := WithType(assert.AnError, ConnectionError)
+	errorString := fmt.Sprintf("%+v", err)
+	t.Log(errorString)
+	assert.Contains(t, errorString, "spark-connect-go/spark/sparkerrors/errors_test.go")
 }
 
 func TestErrorDetailsExtractionFromGRPCStatus(t *testing.T) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Adding stack trace support to spark errors via the commonly used "github.com/go-errors/errors" library

https://github.com/apache/spark-connect-go/issues/63


### Why are the changes needed?
Increased debugability

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Unit test added
