### PR TITLE
feat: init devenv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+source_url "https://raw.githubusercontent.com/cachix/devenv/95f329d49a8a5289d31e0982652f7058a189bfca/direnvrc" "sha256-d+8cBpDfDBj41inrADaJt+bDWhOktwslgoP5YiGJ1v0="
+
+use devenv

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,12 @@ target
 lib
 
 deps
+# Devenv
+.devenv*
+devenv.local.nix
+
+# direnv
+.direnv
+
+# pre-commit
+.pre-commit-config.yaml

--- a/README.md
+++ b/README.md
@@ -44,6 +44,31 @@ Step 5: Run the example Go application.
 go run cmd/spark-connect-example-spark-session/main.go
 ```
 
+### Using Devenv
+
+If you prefer using [Devenv](https://devenv.sh) for a streamlined development environment
+when working with Spark Connect Go,
+follow the steps below:
+
+1. **Install Devenv:** Make sure [Devenv is installed](https://devenv.sh/getting-started/#installation).
+
+2. **Enable Devenv:**
+
+   Run the following command to activate the development environment:
+
+   ```bash
+   devenv shell
+   ```
+
+3. Run the example Go application.
+
+    ```
+    go run cmd/spark-connect-example-spark-session/main.go
+    ```
+
+By using Devenv, you ensure a consistent environment across different machines,
+with dependencies pinned to specific versions as defined in
+your devenv.nix configuration.
 ## How to write Spark Connect Go Application in your own project
 
 See [Quick Start Guide](quick-start.md)

--- a/devenv.lock
+++ b/devenv.lock
@@ -1,0 +1,122 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1726417371,
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "1f55f89ca32d617b7a7c18422e3c364cb003df3d",
+        "treeHash": "b6e4651ee4f4a5a9708e4c815783148d705c7027",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "treeHash": "2addb7b71a20a25ea74feeaf5c2f6a6b30898ecb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "treeHash": "ca14199cabdfe1a06a7b1654c76ed49100a689f9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1716977621,
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "4267e705586473d3e5c8d50299e71503f16a6fb6",
+        "treeHash": "6d9f1f7ca0faf1bc2eeb397c78a49623260d3412",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1726320982,
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8f7492cce28977fbf8bd12c72af08b1f6c7c3e49",
+        "treeHash": "01138919459f4bdcf23e6289eaf3329667e00707",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1725513492,
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "7570de7b9b504cfe92025dd1be797bf546f66528",
+        "treeHash": "4b46d77870afecd8f642541cb4f4927326343b59",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -7,12 +7,19 @@
   # https://devenv.sh/packages/
   packages = with pkgs; [
     git
-    spark
+    (pkgs.spark.overrideAttrs (oldAttrs: {
+      version = "3.5.1";
+    }))
+
+    (pkgs.protobuf.overrideAttrs (oldAttrs: {
+      version = "24.4"; 
+    }))
   ];
 
   # https://devenv.sh/languages/
   languages.java.enable = true;
-  languages.java.jdk.package = pkgs.jdk11; 
+  languages.java.jdk.package = pkgs.jdk11;
+  languages.go.enable = true;
 
   # https://devenv.sh/processes/
   # processes.cargo-watch.exec = "cargo-watch";
@@ -21,13 +28,19 @@
   # services.postgres.enable = true;
 
   # https://devenv.sh/scripts/
-  scripts.hello.exec = ''
-    echo hello from $GREET
-  '';
+  scripts = {
+    hello.exec = ''
+      echo hello from $GREET
+    '';
+    run-spark-connect.exec = ''
+      sudo start-connect-server.sh --packages org.apache.spark:spark-connect_2.12:3.5.1
+    '';
+  };
 
   enterShell = ''
     hello
     spark-shell --version
+    run-spark-connect
   '';
 
   # https://devenv.sh/tests/

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,0 +1,43 @@
+{ pkgs, lib, config, inputs, ... }:
+
+{
+  # https://devenv.sh/basics/
+  env.GREET = "devenv";
+
+  # https://devenv.sh/packages/
+  packages = with pkgs; [
+    git
+    spark
+  ];
+
+  # https://devenv.sh/languages/
+  languages.java.enable = true;
+  languages.java.jdk.package = pkgs.jdk11; 
+
+  # https://devenv.sh/processes/
+  # processes.cargo-watch.exec = "cargo-watch";
+
+  # https://devenv.sh/services/
+  # services.postgres.enable = true;
+
+  # https://devenv.sh/scripts/
+  scripts.hello.exec = ''
+    echo hello from $GREET
+  '';
+
+  enterShell = ''
+    hello
+    spark-shell --version
+  '';
+
+  # https://devenv.sh/tests/
+  enterTest = ''
+    echo "Running tests"
+    git --version | grep --color=auto "${pkgs.git.version}"
+  '';
+
+  # https://devenv.sh/pre-commit-hooks/
+  # pre-commit.hooks.shellcheck.enable = true;
+
+  # See full reference at https://devenv.sh/reference/options/
+}

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://devenv.sh/devenv.schema.json
+inputs:
+  nixpkgs:
+    url: github:cachix/devenv-nixpkgs/rolling
+
+# If you're using non-OSS software, you can set allowUnfree to true.
+# allowUnfree: true
+
+# If you're willing to use a package that's vulnerable
+# permittedInsecurePackages:
+#  - "openssl-1.1.1w"
+
+# If you have more than one devenv you can merge them
+#imports:
+# - ./backend


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR introduces [Devenv](https://devenv.sh/) to enhance the developer experience by providing a simpler and faster setup process for the development environment. With Devenv, setting up the development environment is now as simple as running:

```sh
devenv shell
sudo start-connect-server.sh --packages org.apache.spark:spark-connect_2.12:3.5.1
```
This command will automatically launch a running Spark Connect instance.
(I will add more detailed documentation if the overall approach is accepted.)

<img width="1719" alt="Screenshot 2024-09-17 at 11 39 17" src="https://github.com/user-attachments/assets/7d142ccd-d127-4814-bf2b-2b1ee869d93f">

In the screen shot you can see how does it look like in the action ☝️ 

### Why are the changes needed?

- Developers can easily set up identical development environments with the same versions across different operating systems.
  - The setup process takes less than 2 minutes to complete, providing a fully functional development environment.
- All application versions (Java, Spark, etc.) are locked, ensuring consistent behavior across all environments.
- This setup is optional and does not interfere with manual installations, catering to developers who prefer an automated setup.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
If the approach is accepted, We can add build and test Github actions related to Devenv for automating testing the development environment (Example Actions: [install-nix-action](https://github.com/cachix/install-nix-action) and [cachix-action](https://github.com/cachix/cachix-action)).