### PR TITLE
Improve channel builder for external applications

### DIFF
--- a/spark/client/channel/channel.go
+++ b/spark/client/channel/channel.go
@@ -22,11 +22,12 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"github.com/google/uuid"
 	"net"
 	"net/url"
 	"strconv"
 	"strings"
+
+	"github.com/google/uuid"
 
 	"google.golang.org/grpc/credentials/insecure"
 

--- a/spark/client/channel/channel_test.go
+++ b/spark/client/channel/channel_test.go
@@ -18,9 +18,10 @@ package channel_test
 
 import (
 	"context"
-	"github.com/google/uuid"
 	"strings"
 	"testing"
+
+	"github.com/google/uuid"
 
 	"github.com/apache/spark-connect-go/v35/spark/client/channel"
 	"github.com/apache/spark-connect-go/v35/spark/sparkerrors"
@@ -75,12 +76,12 @@ func TestBasicChannelParsing(t *testing.T) {
 	assert.Equal(t, "token", cb.Token())
 	assert.Equal(t, "user_id", cb.User())
 	assert.Equal(t, "session", cb.SessionId())
-
 }
 
 func TestChannelBuildConnect(t *testing.T) {
 	ctx := context.Background()
 	cb, err := channel.NewBuilder("sc://localhost")
+	assert.NoError(t, err)
 	id := cb.SessionId()
 	_, err = uuid.Parse(id)
 	assert.NoError(t, err)

--- a/spark/client/channel/channel_test.go
+++ b/spark/client/channel/channel_test.go
@@ -18,6 +18,7 @@ package channel_test
 
 import (
 	"context"
+	"github.com/google/uuid"
 	"strings"
 	"testing"
 
@@ -67,17 +68,22 @@ func TestBasicChannelParsing(t *testing.T) {
 	assert.Equal(t, "a", cb.User())
 	assert.Equal(t, "b", cb.Token())
 
-	cb, err = channel.NewBuilder("sc://localhost:443/;token=token;user_id=user_id;cluster_id=a")
+	cb, err = channel.NewBuilder("sc://localhost:443/;token=token;user_id=user_id;cluster_id=a;session_id=session")
 	assert.NoError(t, err)
 	assert.Equal(t, 443, cb.Port())
 	assert.Equal(t, "localhost", cb.Host())
 	assert.Equal(t, "token", cb.Token())
 	assert.Equal(t, "user_id", cb.User())
+	assert.Equal(t, "session", cb.SessionId())
+
 }
 
 func TestChannelBuildConnect(t *testing.T) {
 	ctx := context.Background()
 	cb, err := channel.NewBuilder("sc://localhost")
+	id := cb.SessionId()
+	_, err = uuid.Parse(id)
+	assert.NoError(t, err)
 	assert.NoError(t, err, "Should not have an error for a proper URL.")
 	conn, err := cb.Build(ctx)
 	assert.Nil(t, err, "no error for proper connection")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Minor improvements and documentation for the `SessionBuilder` that allow other external clients to configure the channel.

### Why are the changes needed?
Compatibility

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Added UT.