### PR TITLE
[#58] Add CreateDataFrame, Corr, Cov,  Count, ColRegex, Columns

### DIFF
--- a/internal/tests/integration/dataframe_test.go
+++ b/internal/tests/integration/dataframe_test.go
@@ -195,3 +195,20 @@ func TestDataFrame_Corr(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, -0.3592106040535498, res)
 }
+
+func TestDataFrame_Cov(t *testing.T) {
+	ctx, spark := connect()
+	data := [][]any{
+		{1, 12}, {10, 1}, {19, 8},
+	}
+	schema := types.StructOf(
+		types.NewStructField("c1", types.INTEGER),
+		types.NewStructField("c2", types.INTEGER),
+	)
+
+	df, err := spark.CreateDataFrame(ctx, data, schema)
+	assert.NoError(t, err)
+	res, err := df.Cov(ctx, "c1", "c2")
+	assert.NoError(t, err)
+	assert.Equal(t, -18.0, res)
+}

--- a/internal/tests/integration/sql_test.go
+++ b/internal/tests/integration/sql_test.go
@@ -17,6 +17,7 @@ package integration
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"testing"
@@ -69,13 +70,23 @@ func TestIntegration_Schema(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	pid, err := StartSparkConnect()
-	if err != nil {
-		log.Fatal(err)
+	envShouldStartService := os.Getenv("START_SPARK_CONNECT_SERVICE")
+	shouldStartService := envShouldStartService == "" || envShouldStartService == "1"
+	pid := int64(-1)
+	var err error
+
+	if shouldStartService {
+		fmt.Println("Starting Spark Connect service...")
+		pid, err = StartSparkConnect()
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 	code := m.Run()
-	if err = StopSparkConnect(pid); err != nil {
-		log.Fatal(err)
+	if shouldStartService {
+		if err = StopSparkConnect(pid); err != nil {
+			log.Fatal(err)
+		}
 	}
 	os.Exit(code)
 }

--- a/spark/sparkerrors/errors.go
+++ b/spark/sparkerrors/errors.go
@@ -64,6 +64,8 @@ var (
 	RetriesExceeded               = errorType(errors.New("retries exceeded"))
 	InvalidServerSideSessionError = errorType(errors.New("invalid server side session"))
 	TestSetupError                = errorType(errors.New("test setup error"))
+	WriteError                    = errorType(errors.New("write error"))
+	NotImplementedError           = errorType(errors.New("not implemented"))
 )
 
 // Format formats the error, supporting both short forms (v, s, q) and verbose form (+v)

--- a/spark/sql/column/column.go
+++ b/spark/sql/column/column.go
@@ -103,3 +103,8 @@ type SchemaDataFrame interface {
 func OfDF(df SchemaDataFrame, colName string) Column {
 	return NewColumn(&delayedColumnReference{colName, df})
 }
+
+func OfDFWithRegex(df SchemaDataFrame, colRegex string) Column {
+	planId := df.PlanId()
+	return NewColumn(&unresolvedRegex{colRegex, &planId})
+}

--- a/spark/sql/column/expressions.go
+++ b/spark/sql/column/expressions.go
@@ -35,6 +35,26 @@ type expression interface {
 	DebugString() string
 }
 
+type unresolvedRegex struct {
+	colRegex string
+	planId   *int64
+}
+
+func (d *unresolvedRegex) DebugString() string {
+	return d.colRegex
+}
+
+func (d *unresolvedRegex) ToProto(ctx context.Context) (*proto.Expression, error) {
+	expr := newProtoExpression()
+	expr.ExprType = &proto.Expression_UnresolvedRegex_{
+		UnresolvedRegex: &proto.Expression_UnresolvedRegex{
+			ColName: d.colRegex,
+			PlanId:  d.planId,
+		},
+	}
+	return expr, nil
+}
+
 type delayedColumnReference struct {
 	unparsedIdentifier string
 	df                 SchemaDataFrame

--- a/spark/sql/dataframe.go
+++ b/spark/sql/dataframe.go
@@ -44,6 +44,29 @@ type DataFrame interface {
 	Show(ctx context.Context, numRows int, truncate bool) error
 	// Schema returns the schema for the current data frame.
 	Schema(ctx context.Context) (*types.StructType, error)
+	// Coalesce returns a new DataFrame that has exactly numPartitions partitions.DataFrame
+	//
+	// Similar to coalesce defined on an :class:`RDD`, this operation results in a
+	// narrow dependency, e.g. if you go from 1000 partitions to 100 partitions,
+	// there will not be a shuffle, instead each of the 100 new partitions will
+	// claim 10 of the current partitions. If a larger number of partitions is requested,
+	// it will stay at the current number of partitions.
+	//
+	// However, if you're doing a drastic coalesce, e.g. to numPartitions = 1,
+	// this may result in your computation taking place on fewer nodes than
+	// you like (e.g. one node in the case of numPartitions = 1). To avoid this,
+	// you can call repartition(). This will add a shuffle step, but means the
+	// current upstream partitions will be executed in parallel (per whatever
+	// the current partitioning is).
+	Coalesce(ctx context.Context, numPartitions int) DataFrame
+
+	Columns(ctx context.Context) ([]string, error)
+
+	Corr(ctx context.Context, col1, col2 string) (float64, error)
+	CorrWithMethod(ctx context.Context, col1, col2 string, method string) (float64, error)
+
+	Count(ctx context.Context) (int64, error)
+
 	// Collect returns the data rows of the current data frame.
 	Collect(ctx context.Context) ([]Row, error)
 	// Writer returns a data frame writer, which could be used to save data frame to supported storage.
@@ -78,6 +101,92 @@ type DataFrame interface {
 type dataFrameImpl struct {
 	session  *sparkSessionImpl
 	relation *proto.Relation // TODO change to proto.Plan?
+}
+
+func (df *dataFrameImpl) Coalesce(ctx context.Context, numPartitions int) DataFrame {
+	shuffle := false
+	rel := &proto.Relation{
+		Common: &proto.RelationCommon{
+			PlanId: newPlanId(),
+		},
+		RelType: &proto.Relation_Repartition{
+			Repartition: &proto.Repartition{
+				Input:         df.relation,
+				Shuffle:       &shuffle,
+				NumPartitions: int32(numPartitions),
+			},
+		},
+	}
+	return NewDataFrame(df.session, rel)
+}
+
+func (df *dataFrameImpl) Columns(ctx context.Context) ([]string, error) {
+	schema, err := df.Schema(ctx)
+	if err != nil {
+		return nil, err
+	}
+	columns := make([]string, len(schema.Fields))
+	for i, field := range schema.Fields {
+		columns[i] = field.Name
+	}
+	return columns, nil
+}
+
+func (df *dataFrameImpl) Corr(ctx context.Context, col1, col2 string) (float64, error) {
+	return df.CorrWithMethod(ctx, col1, col2, "pearson")
+}
+
+func (df *dataFrameImpl) CorrWithMethod(ctx context.Context, col1, col2 string, method string) (float64, error) {
+	plan := &proto.Plan{
+		OpType: &proto.Plan_Root{
+			Root: &proto.Relation{
+				Common: &proto.RelationCommon{
+					PlanId: newPlanId(),
+				},
+				RelType: &proto.Relation_Corr{
+					Corr: &proto.StatCorr{
+						Input:  df.relation,
+						Col1:   col1,
+						Col2:   col2,
+						Method: &method,
+					},
+				},
+			},
+		},
+	}
+
+	responseClient, err := df.session.client.ExecutePlan(ctx, plan)
+	if err != nil {
+		return 0, sparkerrors.WithType(fmt.Errorf("failed to execute plan: %w", err), sparkerrors.ExecutionError)
+	}
+
+	_, table, err := responseClient.ToTable()
+	if err != nil {
+		return 0, err
+	}
+
+	values, err := types.ReadArrowTable(table)
+	if err != nil {
+		return 0, err
+	}
+
+	return values[0][0].(float64), nil
+}
+
+func (df *dataFrameImpl) Count(ctx context.Context) (int64, error) {
+	res, err := df.GroupBy().Count(ctx)
+	if err != nil {
+		return 0, err
+	}
+	rows, err := res.Collect(ctx)
+	if err != nil {
+		return 0, err
+	}
+	row, err := rows[0].Values()
+	if err != nil {
+		return 0, err
+	}
+	return row[0].(int64), nil
 }
 
 func (df *dataFrameImpl) PlanId() int64 {

--- a/spark/sql/types/datatype.go
+++ b/spark/sql/types/datatype.go
@@ -19,11 +19,14 @@ package types
 import (
 	"fmt"
 	"strings"
+
+	"github.com/apache/arrow/go/v17/arrow"
 )
 
 type DataType interface {
 	TypeName() string
 	IsNumeric() bool
+	ToArrowType() arrow.DataType
 }
 
 type BooleanType struct{}
@@ -36,10 +39,18 @@ func (t BooleanType) IsNumeric() bool {
 	return false
 }
 
+func (t BooleanType) ToArrowType() arrow.DataType {
+	return arrow.FixedWidthTypes.Boolean
+}
+
 type ByteType struct{}
 
 func (t ByteType) IsNumeric() bool {
 	return true
+}
+
+func (t ByteType) ToArrowType() arrow.DataType {
+	return arrow.PrimitiveTypes.Int8
 }
 
 func (t ByteType) TypeName() string {
@@ -56,6 +67,10 @@ func (t ShortType) IsNumeric() bool {
 	return true
 }
 
+func (t ShortType) ToArrowType() arrow.DataType {
+	return arrow.PrimitiveTypes.Int16
+}
+
 type IntegerType struct{}
 
 func (t IntegerType) TypeName() string {
@@ -64,6 +79,10 @@ func (t IntegerType) TypeName() string {
 
 func (t IntegerType) IsNumeric() bool {
 	return true
+}
+
+func (t IntegerType) ToArrowType() arrow.DataType {
+	return arrow.PrimitiveTypes.Int32
 }
 
 type LongType struct{}
@@ -76,6 +95,10 @@ func (t LongType) IsNumeric() bool {
 	return true
 }
 
+func (t LongType) ToArrowType() arrow.DataType {
+	return arrow.PrimitiveTypes.Int64
+}
+
 type FloatType struct{}
 
 func (t FloatType) TypeName() string {
@@ -84,6 +107,10 @@ func (t FloatType) TypeName() string {
 
 func (t FloatType) IsNumeric() bool {
 	return true
+}
+
+func (t FloatType) ToArrowType() arrow.DataType {
+	return arrow.PrimitiveTypes.Float32
 }
 
 type DoubleType struct{}
@@ -96,7 +123,14 @@ func (t DoubleType) IsNumeric() bool {
 	return true
 }
 
-type DecimalType struct{}
+func (t DoubleType) ToArrowType() arrow.DataType {
+	return arrow.PrimitiveTypes.Float64
+}
+
+type DecimalType struct {
+	Precision int32
+	Scale     int32
+}
 
 func (t DecimalType) TypeName() string {
 	return getDataTypeName(t)
@@ -104,6 +138,13 @@ func (t DecimalType) TypeName() string {
 
 func (t DecimalType) IsNumeric() bool {
 	return true
+}
+
+func (t DecimalType) ToArrowType() arrow.DataType {
+	return &arrow.Decimal128Type{
+		Precision: t.Precision,
+		Scale:     t.Scale,
+	}
 }
 
 type StringType struct{}
@@ -116,6 +157,10 @@ func (t StringType) IsNumeric() bool {
 	return false
 }
 
+func (t StringType) ToArrowType() arrow.DataType {
+	return arrow.BinaryTypes.String
+}
+
 type BinaryType struct{}
 
 func (t BinaryType) TypeName() string {
@@ -124,6 +169,10 @@ func (t BinaryType) TypeName() string {
 
 func (t BinaryType) IsNumeric() bool {
 	return false
+}
+
+func (t BinaryType) ToArrowType() arrow.DataType {
+	return arrow.BinaryTypes.Binary
 }
 
 type TimestampType struct{}
@@ -136,6 +185,10 @@ func (t TimestampType) IsNumeric() bool {
 	return false
 }
 
+func (t TimestampType) ToArrowType() arrow.DataType {
+	return arrow.FixedWidthTypes.Timestamp_ms
+}
+
 type TimestampNtzType struct{}
 
 func (t TimestampNtzType) TypeName() string {
@@ -146,6 +199,10 @@ func (t TimestampNtzType) IsNumeric() bool {
 	return false
 }
 
+func (t TimestampNtzType) ToArrowType() arrow.DataType {
+	return arrow.FixedWidthTypes.Timestamp_ns
+}
+
 type DateType struct{}
 
 func (t DateType) TypeName() string {
@@ -154,6 +211,10 @@ func (t DateType) TypeName() string {
 
 func (t DateType) IsNumeric() bool {
 	return false
+}
+
+func (t DateType) ToArrowType() arrow.DataType {
+	return arrow.FixedWidthTypes.Date32
 }
 
 type UnsupportedType struct {
@@ -168,8 +229,26 @@ func (t UnsupportedType) IsNumeric() bool {
 	return false
 }
 
+func (t UnsupportedType) ToArrowType() arrow.DataType {
+	return nil
+}
+
 func getDataTypeName(dataType DataType) string {
 	typeName := fmt.Sprintf("%T", dataType)
 	nonQualifiedTypeName := strings.Split(typeName, ".")[1]
 	return strings.TrimSuffix(nonQualifiedTypeName, "Type")
 }
+
+var (
+	BOOLEAN       = BooleanType{}
+	BYTE          = ByteType{}
+	SHORT         = ShortType{}
+	INTEGER       = IntegerType{}
+	LONG          = LongType{}
+	FLOAT         = FloatType{}
+	DOUBLE        = DoubleType{}
+	DATE          = DateType{}
+	TIMESTAMP     = TimestampType{}
+	TIMESTAMP_NTZ = TimestampNtzType{}
+	STRING        = StringType{}
+)

--- a/spark/sql/types/structtype.go
+++ b/spark/sql/types/structtype.go
@@ -16,6 +16,8 @@
 
 package types
 
+import "github.com/apache/arrow/go/v17/arrow"
+
 // StructField represents a field in a StructType.
 type StructField struct {
 	Name     string
@@ -23,8 +25,43 @@ type StructField struct {
 	Nullable bool // default should be true
 }
 
+func (t *StructField) ToArrowType() arrow.Field {
+	return arrow.Field{
+		Name:     t.Name,
+		Type:     t.DataType.ToArrowType(),
+		Nullable: t.Nullable,
+	}
+}
+
 // StructType represents a struct type.
 type StructType struct {
-	TypeName string
-	Fields   []StructField
+	Fields []StructField
+}
+
+func (t *StructType) TypeName() string {
+	return "structtype"
+}
+
+func (t *StructType) IsNumeric() bool {
+	return false
+}
+
+func (t *StructType) ToArrowType() *arrow.StructType {
+	fields := make([]arrow.Field, len(t.Fields))
+	for i, f := range t.Fields {
+		fields[i] = f.ToArrowType()
+	}
+	return arrow.StructOf(fields...)
+}
+
+func StructOf(fields ...StructField) *StructType {
+	return &StructType{Fields: fields}
+}
+
+func NewStructField(name string, dataType DataType) StructField {
+	return StructField{
+		Name:     name,
+		DataType: dataType,
+		Nullable: true,
+	}
 }

--- a/spark/sql/types/structtype_test.go
+++ b/spark/sql/types/structtype_test.go
@@ -1,0 +1,28 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStructOf(t *testing.T) {
+	s := StructOf(NewStructField("col1", BYTE))
+	assert.Len(t, s.Fields, 1)
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds a collection of specific DataFrame functionality to further include coverage of the Spark Connect Go client:


DataFrame:

* `DF.Coalesce()`
* `DF.Corr()`
* `DF.Cov()`
* `DF.CorrWithMethod()`
* `DF.Count()`
* `DF.Columns()`

SparkSession:

* `SparkSession.CreateDataFrameFromArrow()`
* `SparkSession.CreateDataFrame()`


### Why are the changes needed?
Compatibility.

### Does this PR introduce _any_ user-facing change?
Adding new functionality.

### How was this patch tested?
Added UT and Integration tests.