### PR TITLE
[#58] Add Support for more DataFrame functions

### DIFF
--- a/spark/sql/types/conversion.go
+++ b/spark/sql/types/conversion.go
@@ -45,6 +45,8 @@ func ConvertProtoStructField(field *generated.DataType_StructField) StructField 
 	return StructField{
 		Name:     field.Name,
 		DataType: ConvertProtoDataTypeToDataType(field.DataType),
+		Nullable: field.Nullable,
+		Metadata: field.Metadata,
 	}
 }
 

--- a/spark/sql/types/structtype.go
+++ b/spark/sql/types/structtype.go
@@ -23,6 +23,7 @@ type StructField struct {
 	Name     string
 	DataType DataType
 	Nullable bool // default should be true
+	Metadata *string
 }
 
 func (t *StructField) ToArrowType() arrow.Field {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This patch adds basic support for the following DataFrame functions:

* `WithColumn()`
* `WithColumns()`
* `WithColumnRenamed()`
* `WithColumnsRenamed()`
* `Drop()`
* `WithWatermark()`
* `WithMetadata()`
* `DropDuplicates()`
* `WithMetadata()`

### Why are the changes needed?
Compatibility

### Does this PR introduce _any_ user-facing change?
Adding new functions


### How was this patch tested?
Added E2E tests.