### PR TITLE
[#58] More DataFrame Features

### DIFF
--- a/internal/tests/integration/dataframe_test.go
+++ b/internal/tests/integration/dataframe_test.go
@@ -458,7 +458,9 @@ func TestDataFrame_CachingAndPersistence(t *testing.T) {
 		assert.NoError(t, err)
 		l, err := df.GetStorageLevel(ctx)
 		assert.NoError(t, err)
-		assert.Equal(t, lvl, *l, "%v != %v", lvl, *l)
+
+		assert.Contains(t, []utils.StorageLevel{lvl, utils.StorageLevelMemoryOnly}, *l)
+
 		err = df.Unpersist(ctx)
 		assert.NoError(t, err)
 	}

--- a/internal/tests/integration/dataframe_test.go
+++ b/internal/tests/integration/dataframe_test.go
@@ -19,6 +19,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/apache/spark-connect-go/v35/spark/sql/utils"
+
 	"github.com/apache/spark-connect-go/v35/spark/sql/types"
 
 	"github.com/apache/spark-connect-go/v35/spark/sql/column"
@@ -248,8 +250,8 @@ func TestDataFrame_WithColumns(t *testing.T) {
 		vals, err := row.Values()
 		assert.NoError(t, err)
 		assert.Equal(t, 3, len(vals))
-		assert.Equal(t, int64(1), vals[1])
-		assert.Equal(t, int64(2), vals[2])
+		assert.Equal(t, int64(1), vals[1], "%v", vals)
+		assert.Equal(t, int64(2), vals[2], "%v", vals)
 	}
 }
 
@@ -408,4 +410,116 @@ func TestDataFrame_DropDuplicates(t *testing.T) {
 	res, err = df.Count(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(1), res)
+}
+
+func TestDataFrame_Explain(t *testing.T) {
+	ctx, spark := connect()
+	df, err := spark.Sql(ctx, "select * from range(10)")
+	assert.NoError(t, err)
+	res, err := df.Explain(ctx, utils.ExplainModeSimple)
+	assert.NoError(t, err)
+	assert.Contains(t, res, "Physical Plan")
+
+	res, err = df.Explain(ctx, utils.ExplainModeExtended)
+	assert.NoError(t, err)
+	assert.Contains(t, res, "Physical Plan")
+
+	res, err = df.Explain(ctx, utils.ExplainModeCodegen)
+	assert.NoError(t, err)
+	assert.Contains(t, res, "WholeStageCodegen")
+
+	res, err = df.Explain(ctx, utils.ExplainModeCost)
+	assert.NoError(t, err)
+	assert.Contains(t, res, "Physical Plan")
+
+	res, err = df.Explain(ctx, utils.ExplainModeFormatted)
+	assert.NoError(t, err)
+	assert.Contains(t, res, "Physical Plan")
+}
+
+func TestDataFrame_CachingAndPersistence(t *testing.T) {
+	ctx, spark := connect()
+	levels := []utils.StorageLevel{
+		utils.StorageLevelDiskOnly,
+		utils.StorageLevelDiskOnly2,
+		utils.StorageLevelDiskOnly3,
+		utils.StorageLevelMemoryAndDisk,
+		utils.StorageLevelMemoryAndDisk2,
+		utils.StorageLevelMemoryOnly,
+		utils.StorageLevelMemoryOnly2,
+		utils.StorageLevelMemoyAndDiskDeser,
+		utils.StorageLevelOffHeap,
+	}
+
+	for _, lvl := range levels {
+		df, err := spark.Sql(ctx, "select * from range(10)")
+		assert.NoError(t, err)
+		err = df.Persist(ctx, lvl)
+		assert.NoError(t, err)
+		l, err := df.GetStorageLevel(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, lvl, *l, "%v != %v", lvl, *l)
+		err = df.Unpersist(ctx)
+		assert.NoError(t, err)
+	}
+	df, err := spark.Sql(ctx, "select * from range(10)")
+	assert.NoError(t, err)
+	err = df.Cache(ctx)
+	assert.NoError(t, err)
+	l, err := df.GetStorageLevel(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, utils.StorageLevelMemoryOnly, *l, "%v != %v", utils.StorageLevelMemoryOnly, *l)
+}
+
+func TestDataFrame_SetOps(t *testing.T) {
+	ctx, spark := connect()
+	df1, err := spark.Sql(ctx, "select * from range(10)")
+	assert.NoError(t, err)
+	df2, err := spark.Sql(ctx, "select * from range(5)")
+	assert.NoError(t, err)
+
+	df := df1.Union(ctx, df2)
+	res, err := df.Collect(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, 15, len(res))
+
+	df = df1.Intersect(ctx, df2)
+	res, err = df.Collect(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, 5, len(res))
+
+	df = df1.ExceptAll(ctx, df2)
+	res, err = df.Collect(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, 5, len(res))
+}
+
+func TestDataFrame_ToArrow(t *testing.T) {
+	ctx, spark := connect()
+	df, err := spark.Sql(ctx, "select * from range(10)")
+	assert.NoError(t, err)
+	tbl, err := df.ToArrow(ctx)
+	assert.NoError(t, err)
+	assert.NotNil(t, tbl)
+}
+
+func TestDataFrame_LimitVersions(t *testing.T) {
+	ctx, spark := connect()
+	df, err := spark.Sql(ctx, "select * from range(10)")
+	assert.NoError(t, err)
+	rows, err := df.Limit(ctx, int32(5))
+	assert.NoError(t, err)
+	assert.Len(t, rows, 5)
+
+	rows, err = df.Tail(ctx, int32(3))
+	assert.NoError(t, err)
+	assert.Len(t, rows, 3)
+
+	rows, err = df.Head(ctx, int32(3))
+	assert.NoError(t, err)
+	assert.Len(t, rows, 3)
+
+	rows, err = df.Take(ctx, int32(3))
+	assert.NoError(t, err)
+	assert.Len(t, rows, 3)
 }

--- a/spark/client/base/base.go
+++ b/spark/client/base/base.go
@@ -18,6 +18,8 @@ package base
 import (
 	"context"
 
+	"github.com/apache/spark-connect-go/v35/spark/sql/utils"
+
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/spark-connect-go/v35/internal/generated"
 	"github.com/apache/spark-connect-go/v35/spark/sql/types"
@@ -33,6 +35,14 @@ type SparkConnectClient interface {
 	ExecutePlan(ctx context.Context, plan *generated.Plan) (ExecuteResponseStream, error)
 	ExecuteCommand(ctx context.Context, plan *generated.Plan) (arrow.Table, *types.StructType, map[string]any, error)
 	AnalyzePlan(ctx context.Context, plan *generated.Plan) (*generated.AnalyzePlanResponse, error)
+	Explain(ctx context.Context, plan *generated.Plan, explainMode utils.ExplainMode) (*generated.AnalyzePlanResponse, error)
+	Persist(ctx context.Context, plan *generated.Plan, storageLevel utils.StorageLevel) error
+	Unpersist(ctx context.Context, plan *generated.Plan) error
+	GetStorageLevel(ctx context.Context, plan *generated.Plan) (*utils.StorageLevel, error)
+	SparkVersion(ctx context.Context) (string, error)
+	DDLParse(ctx context.Context, sql string) (*types.StructType, error)
+	SameSemantics(ctx context.Context, plan1 *generated.Plan, plan2 *generated.Plan) (bool, error)
+	SemanticHash(ctx context.Context, plan *generated.Plan) (int32, error)
 }
 
 type ExecuteResponseStream interface {

--- a/spark/mocks/mock_executor.go
+++ b/spark/mocks/mock_executor.go
@@ -17,6 +17,9 @@ package mocks
 
 import (
 	"context"
+	"errors"
+
+	"github.com/apache/spark-connect-go/v35/spark/sql/utils"
 
 	"github.com/apache/spark-connect-go/v35/spark/client/base"
 
@@ -42,9 +45,43 @@ func (t *TestExecutor) AnalyzePlan(ctx context.Context, plan *generated.Plan) (*
 	return t.response, nil
 }
 
+func (t *TestExecutor) Explain(ctx context.Context, plan *generated.Plan,
+	explainMode utils.ExplainMode,
+) (*generated.AnalyzePlanResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (t *TestExecutor) ExecuteCommand(ctx context.Context, plan *generated.Plan) (arrow.Table, *types.StructType, map[string]interface{}, error) {
 	if t.Err != nil {
 		return nil, nil, nil, t.Err
 	}
 	return nil, nil, nil, nil
+}
+
+func (t *TestExecutor) Persist(ctx context.Context, plan *generated.Plan, storageLevel utils.StorageLevel) error {
+	return errors.New("not implemented")
+}
+
+func (t *TestExecutor) Unpersist(ctx context.Context, plan *generated.Plan) error {
+	return errors.New("not implemented")
+}
+
+func (t *TestExecutor) GetStorageLevel(ctx context.Context, plan *generated.Plan) (*utils.StorageLevel, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (t *TestExecutor) SparkVersion(ctx context.Context) (string, error) {
+	return "", errors.New("not implemented")
+}
+
+func (t *TestExecutor) DDLParse(ctx context.Context, sql string) (*types.StructType, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (t *TestExecutor) SameSemantics(ctx context.Context, plan1 *generated.Plan, plan2 *generated.Plan) (bool, error) {
+	return false, errors.New("not implemented")
+}
+
+func (t *TestExecutor) SemanticHash(ctx context.Context, plan *generated.Plan) (int32, error) {
+	return 0, errors.New("not implemented")
 }

--- a/spark/sparkerrors/errors.go
+++ b/spark/sparkerrors/errors.go
@@ -66,6 +66,7 @@ var (
 	TestSetupError                = errorType(errors.New("test setup error"))
 	WriteError                    = errorType(errors.New("write error"))
 	NotImplementedError           = errorType(errors.New("not implemented"))
+	InvalidArgumentError          = errorType(errors.New("invalid argument"))
 )
 
 // Format formats the error, supporting both short forms (v, s, q) and verbose form (+v)

--- a/spark/sql/utils/consts.go
+++ b/spark/sql/utils/consts.go
@@ -1,0 +1,98 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import proto "github.com/apache/spark-connect-go/v35/internal/generated"
+
+type ExplainMode int
+
+const (
+	ExplainModeSimple    ExplainMode = iota
+	ExplainModeExtended  ExplainMode = iota
+	ExplainModeCodegen   ExplainMode = iota
+	ExplainModeCost      ExplainMode = iota
+	ExplainModeFormatted ExplainMode = iota
+)
+
+type StorageLevel int
+
+const (
+	StorageLevelDiskOnly          StorageLevel = iota
+	StorageLevelDiskOnly2         StorageLevel = iota
+	StorageLevelDiskOnly3         StorageLevel = iota
+	StorageLevelMemoryAndDisk     StorageLevel = iota
+	StorageLevelMemoryAndDisk2    StorageLevel = iota
+	StorageLevelMemoryOnly        StorageLevel = iota
+	StorageLevelMemoryOnly2       StorageLevel = iota
+	StorageLevelMemoyAndDiskDeser StorageLevel = iota
+	StorageLevelNone              StorageLevel = iota
+	StorageLevelOffHeap           StorageLevel = iota
+)
+
+func ToProtoStorageLevel(level StorageLevel) *proto.StorageLevel {
+	switch level {
+	case StorageLevelDiskOnly:
+		return &proto.StorageLevel{UseDisk: true, UseMemory: false, Replication: 1}
+	case StorageLevelDiskOnly2:
+		return &proto.StorageLevel{UseDisk: true, UseMemory: false, Replication: 2}
+	case StorageLevelDiskOnly3:
+		return &proto.StorageLevel{UseDisk: true, UseMemory: false, Replication: 3}
+	case StorageLevelMemoryAndDisk:
+		return &proto.StorageLevel{UseDisk: true, UseMemory: true, Replication: 1}
+	case StorageLevelMemoryAndDisk2:
+		return &proto.StorageLevel{UseDisk: true, UseMemory: true, Replication: 2}
+	case StorageLevelMemoryOnly:
+		return &proto.StorageLevel{UseDisk: false, UseMemory: true, Replication: 1}
+	case StorageLevelMemoryOnly2:
+		return &proto.StorageLevel{UseDisk: false, UseMemory: true, Replication: 2}
+	case StorageLevelMemoyAndDiskDeser:
+		return &proto.StorageLevel{UseDisk: true, UseMemory: true, Replication: 1, Deserialized: true}
+	case StorageLevelOffHeap:
+		return &proto.StorageLevel{UseDisk: true, UseMemory: true, UseOffHeap: true, Replication: 1}
+	default:
+		return &proto.StorageLevel{UseDisk: false, UseMemory: false, UseOffHeap: false, Replication: 1}
+	}
+}
+
+func FromProtoStorageLevel(level *proto.StorageLevel) StorageLevel {
+	if level.UseDisk && level.UseMemory && level.Replication <= 1 && !level.Deserialized && !level.UseOffHeap {
+		return StorageLevelMemoryAndDisk
+	} else if level.UseDisk && level.UseMemory && level.Replication == 2 && !level.Deserialized && !level.UseOffHeap {
+		return StorageLevelMemoryAndDisk2
+	} else if level.UseDisk && !level.UseMemory && level.Replication == 3 &&
+		!level.Deserialized && !level.UseOffHeap {
+		return StorageLevelDiskOnly3
+	} else if level.UseDisk && !level.UseMemory && level.Replication == 2 &&
+		!level.Deserialized && !level.UseOffHeap {
+		return StorageLevelDiskOnly2
+	} else if level.UseDisk && !level.UseMemory && level.Replication <= 1 &&
+		!level.Deserialized && !level.UseOffHeap {
+		return StorageLevelDiskOnly
+	} else if !level.UseDisk && level.UseMemory && level.Replication <= 1 &&
+		!level.Deserialized && !level.UseOffHeap {
+		return StorageLevelMemoryOnly
+	} else if !level.UseDisk && level.UseMemory && level.Replication == 2 &&
+		!level.Deserialized && !level.UseOffHeap {
+		return StorageLevelMemoryOnly2
+	} else if level.UseDisk && level.UseMemory && level.Replication <= 1 && level.Deserialized && !level.UseOffHeap {
+		return StorageLevelMemoyAndDiskDeser
+	} else if !level.UseDisk && !level.UseMemory && !level.Deserialized && !level.UseOffHeap {
+		return StorageLevelNone
+	} else if level.UseOffHeap && !level.Deserialized {
+		return StorageLevelOffHeap
+	}
+	return StorageLevelNone
+}

--- a/spark/sql/utils/consts_test.go
+++ b/spark/sql/utils/consts_test.go
@@ -1,0 +1,41 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import "testing"
+
+func TestStorageLevelConversion(t *testing.T) {
+	// Given a list of all storage levels, convert them to and from proto and
+	// check with the original value:
+	for _, level := range []StorageLevel{
+		StorageLevelDiskOnly,
+		StorageLevelDiskOnly2,
+		StorageLevelDiskOnly3,
+		StorageLevelMemoryAndDisk,
+		StorageLevelMemoryAndDisk2,
+		StorageLevelMemoryOnly,
+		StorageLevelMemoryOnly2,
+		StorageLevelMemoyAndDiskDeser,
+		StorageLevelNone,
+		StorageLevelOffHeap,
+	} {
+		protoLevel := ToProtoStorageLevel(level)
+		convertedLevel := FromProtoStorageLevel(protoLevel)
+		if level != convertedLevel {
+			t.Errorf("Expected %v, got %v", level, convertedLevel)
+		}
+	}
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
This patch adds support for the following DataFrame operations:

* `ExceptALl`
* `Head`
* `Intersect`
* `IntersectAll`
* `Limit`
* `Subtract`
* `Tail`
* `Take`
* `ToArrow`
* `Union`
* `UnionAll`
* `UnionByName`
* `UnionByNameWithMissingColumns`
* `Explain`
* `StorageLevel`
* `Persist`
* `Unpersist`
* `Cache`

### Why are the changes needed?
Compatibility

### Does this PR introduce _any_ user-facing change?
Adding the above new features.

### How was this patch tested?
Added E2E tests.