### PR TITLE
fix: Row FieldNames() memory allocation

### DIFF
--- a/spark/sql/types/row.go
+++ b/spark/sql/types/row.go
@@ -46,7 +46,7 @@ func (r *rowImpl) Len() int {
 }
 
 func (r *rowImpl) FieldNames() []string {
-	names := make([]string, len(r.offsets))
+	names := make([]string, 0, len(r.offsets))
 	for name := range r.offsets {
 		names = append(names, name)
 	}


### PR DESCRIPTION
### What changes were proposed in this pull request?

The `rowImpl.FieldNames()` array allocation was wrong, resulting in empty strings at the start of the list.

### Why are the changes needed?
To fix the bug.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
In my head^^