### PR TITLE
add option function to spark read

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module github.com/apache/spark-connect-go/v35
+module github.com/amkarkhi/spark-connect-go/v35
 
 go 1.21
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module github.com/amkarkhi/spark-connect-go/v35
+module github.com/apache/spark-connect-go/v35
 
 go 1.21
 

--- a/internal/tests/integration/dataframe_test.go
+++ b/internal/tests/integration/dataframe_test.go
@@ -699,8 +699,8 @@ func TestDataFrame_FreqItems(t *testing.T) {
 
 func TestDataFrame_WithOption(t *testing.T) {
 	ctx, spark := connect()
-	filepath := "/tmp/test.csv"
-	file, err := os.Create(filepath)
+	file, err := os.CreateTemp("", "example")
+	defer os.Remove(file.Name())
 	assert.NoError(t, err)
 	defer file.Close()
 	_, err = file.WriteString("id#name,name\n")
@@ -716,11 +716,9 @@ func TestDataFrame_WithOption(t *testing.T) {
 		Option("escapeQuotes", "true").
 		// Option("skipLines", "5"). //TODO: this needs more insight
 		Option("inferSchema", "false").
-		Load(filepath)
+		Load(file.Name())
 	assert.NoError(t, err)
 	c, err := df.Count(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(10), c)
-	err = os.Remove(filepath)
-	assert.NoError(t, err)
 }

--- a/internal/tests/integration/dataframe_test.go
+++ b/internal/tests/integration/dataframe_test.go
@@ -714,7 +714,7 @@ func TestDataFrame_WithOption(t *testing.T) {
 		Option("quote", "\"").
 		Option("sep", "#").
 		Option("escapeQuotes", "true").
-		Option("skipLines", "5").
+		// Option("skipLines", "5"). //TODO: this needs more insight
 		Option("inferSchema", "false").
 		Load(filepath)
 	assert.NoError(t, err)

--- a/internal/tests/integration/dataframe_test.go
+++ b/internal/tests/integration/dataframe_test.go
@@ -704,6 +704,7 @@ func TestDataFrame_WithOption(t *testing.T) {
 	assert.NoError(t, err)
 	defer file.Close()
 	_, err = file.WriteString("id#name,name\n")
+	assert.NoError(t, err)
 	for i := 0; i < 10; i++ {
 		_, err = file.WriteString(fmt.Sprintf("%d#alice,alice\n", i))
 		assert.NoError(t, err)

--- a/internal/tests/integration/dataframe_test.go
+++ b/internal/tests/integration/dataframe_test.go
@@ -17,6 +17,8 @@ package integration
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/apache/spark-connect-go/v35/spark/sql/utils"
@@ -693,4 +695,31 @@ func TestDataFrame_FreqItems(t *testing.T) {
 	res, err := df.FreqItems(ctx, "id").Collect(ctx)
 	assert.NoErrorf(t, err, "%+v", err)
 	assert.Len(t, res, 1)
+}
+
+func TestDataFrame_WithOption(t *testing.T) {
+	ctx, spark := connect()
+	filepath := "/tmp/test.csv"
+	file, err := os.Create(filepath)
+	assert.NoError(t, err)
+	defer file.Close()
+	_, err = file.WriteString("id#name,name\n")
+	for i := 0; i < 10; i++ {
+		_, err = file.WriteString(fmt.Sprintf("%d#alice,alice\n", i))
+		assert.NoError(t, err)
+	}
+	df, err := spark.Read().Format("csv").
+		Option("header", "true").
+		Option("quote", "\"").
+		Option("sep", "#").
+		Option("escapeQuotes", "true").
+		Option("skipLines", "5").
+		Option("inferSchema", "false").
+		Load(filepath)
+	assert.NoError(t, err)
+	c, err := df.Count(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(10), c)
+	err = os.Remove(filepath)
+	assert.NoError(t, err)
 }

--- a/spark/sql/dataframereader.go
+++ b/spark/sql/dataframereader.go
@@ -26,7 +26,7 @@ type DataFrameReader interface {
 	Load(path string) (DataFrame, error)
 	// Reads a table from the underlying data source.
 	Table(name string) (DataFrame, error)
-	Option(key string, value string) DataFrameReader
+	Option(key, value string) DataFrameReader
 }
 
 // dataFrameReaderImpl is an implementation of DataFrameReader interface.

--- a/spark/sql/dataframereader.go
+++ b/spark/sql/dataframereader.go
@@ -26,12 +26,14 @@ type DataFrameReader interface {
 	Load(path string) (DataFrame, error)
 	// Reads a table from the underlying data source.
 	Table(name string) (DataFrame, error)
+	Option(key string, value string) DataFrameReader
 }
 
 // dataFrameReaderImpl is an implementation of DataFrameReader interface.
 type dataFrameReaderImpl struct {
 	sparkSession *sparkSessionImpl
 	formatSource string
+	options      map[string]string
 }
 
 // NewDataframeReader creates a new DataFrameReader
@@ -55,5 +57,16 @@ func (w *dataFrameReaderImpl) Load(path string) (DataFrame, error) {
 	if w.formatSource != "" {
 		format = w.formatSource
 	}
-	return NewDataFrame(w.sparkSession, newReadWithFormatAndPath(path, format)), nil
+	if w.options == nil {
+		return NewDataFrame(w.sparkSession, newReadWithFormatAndPath(path, format)), nil
+	}
+	return NewDataFrame(w.sparkSession, newReadWithFormatAndPathAndOptions(path, format, w.options)), nil
+}
+
+func (w *dataFrameReaderImpl) Option(key, value string) DataFrameReader {
+	if w.options == nil {
+		w.options = make(map[string]string)
+	}
+	w.options[key] = value
+	return w
 }

--- a/spark/sql/dataframereader_test.go
+++ b/spark/sql/dataframereader_test.go
@@ -39,3 +39,16 @@ func TestRelationContainsPathAndFormat(t *testing.T) {
 	assert.Equal(t, &formatSource, relation.GetRead().GetDataSource().Format)
 	assert.Equal(t, path, relation.GetRead().GetDataSource().Paths[0])
 }
+
+func TestRelationContainsPathAndFormatAndOptions(t *testing.T) {
+	formatSource := "source"
+	path := "path"
+	options := map[string]string{"key": "value"}
+	relation := newReadWithFormatAndPathAndOptions(path, formatSource, options)
+	assert.NotNil(t, relation)
+	assert.Equal(t, &formatSource, relation.GetRead().GetDataSource().Format)
+	assert.Equal(t, path, relation.GetRead().GetDataSource().Paths[0])
+	for i, v := range options {
+		assert.Equal(t, v, relation.GetRead().GetDataSource().Options[i])
+	}
+}

--- a/spark/sql/plan.go
+++ b/spark/sql/plan.go
@@ -64,3 +64,19 @@ func newReadWithFormatAndPath(path, format string) *proto.Relation {
 		},
 	}
 }
+
+func newReadWithFormatAndPathAndOptions(path, format string, options map[string]string) *proto.Relation {
+	return &proto.Relation{
+		RelType: &proto.Relation_Read{
+			Read: &proto.Read{
+				ReadType: &proto.Read_DataSource_{
+					DataSource: &proto.Read_DataSource{
+						Format:  &format,
+						Paths:   []string{path},
+						Options: options,
+					},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION


### What changes were proposed in this pull request?
i wanted to add jdbc driver so i could read from mysql from spark. the option function was not supported in the spark read so i have added this function. now we can use spark.read().option(key,value)


### Why are the changes needed?
using jdbc mostly needs this feature


### Does this PR introduce _any_ user-facing change?
no but it will add more functionality to the user 


### How was this patch tested?
i added a simple test and used it to connect to a mysql server. i just tested conectivity but i had to use this command when starting spark:
```sh
➜  sbin ./start-connect-server.sh --packages org.apache.spark:spark-connect_2.13:3.5.2,org.mariadb-java-client:3.3.2
'''
note: integrity test fails because of my java version. 