### PR TITLE
(FIX Issue #87) Correct Config to accurately set UserContext 

### DIFF
--- a/spark/client/client.go
+++ b/spark/client/client.go
@@ -332,7 +332,12 @@ func (s *sparkConnectClientImpl) SemanticHash(ctx context.Context, plan *proto.P
 }
 
 func (s *sparkConnectClientImpl) Config(ctx context.Context, operation *proto.ConfigRequest_Operation) (*generated.ConfigResponse, error) {
-	request := &proto.ConfigRequest{Operation: operation}
+	request := &proto.ConfigRequest{
+		Operation: operation,
+		UserContext: &proto.UserContext{
+			UserId: "na",
+		},
+	}
 	request.SessionId = s.sessionId
 	resp, err := s.client.Config(ctx, request)
 	if err != nil {


### PR DESCRIPTION
The proto lacked userContext which led to not able to set values correctly for current session & user context.
### What changes were proposed in this pull request?
client.Config() function proto lacked UserContext

### Why are the changes needed?
photo requires a user context that was actually omitted in the development and was not caught since the call seemingly work, but does not set the value in the correct context.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Setting spark.sql.ansi.enabled to true (default false) and running a ansi violation cast as well as getting the value from spark.sql using set and using Config.Get in a golang application. 