### PR TITLE
Added implementations of FillNa

### DIFF
--- a/internal/tests/integration/dataframe_test.go
+++ b/internal/tests/integration/dataframe_test.go
@@ -821,7 +821,7 @@ func TestDataFrame_FillNa(t *testing.T) {
 	assert.NoError(t, err)
 
 	// all columns
-	filled, err := df.FillNa(ctx, 10)
+	filled, err := df.FillNa(ctx, types.Int64(10))
 	assert.NoError(t, err)
 	sorted, err := filled.Sort(ctx, functions.Col("id").Asc())
 	assert.NoError(t, err)
@@ -832,31 +832,26 @@ func TestDataFrame_FillNa(t *testing.T) {
 	assert.Equal(t, []any{int64(10), int64(12), int64(10)}, res[1].Values())
 
 	// specific columns
-	filled, err = df.FillNa(ctx, 10, "int", "int2")
+	filled, err = df.FillNa(ctx, types.Int64(10), "int", "int2")
 	assert.NoError(t, err)
 	sorted, err = filled.Sort(ctx, functions.Col("id").Asc())
 	assert.NoError(t, err)
 	res, err = sorted.Collect(ctx)
 	assert.NoError(t, err)
 	require.Equal(t, 2, len(res))
-	assert.Equal(t, []any{int64(0), int64(12), int64(10)}, res[0].Values())
+	assert.Equal(t, []any{nil, int64(12), int64(10)}, res[0].Values())
 	assert.Equal(t, []any{int64(1), int64(10), int64(1)}, res[1].Values())
 
 	// specific columns with map
-	filled, err = df.FillNaWithValues(ctx, map[string]any{"int": 10, "int2": 20})
+	filled, err = df.FillNaWithValues(ctx, map[string]types.PrimitiveTypeLiteral{
+		"int": types.Int64(10), "int2": types.Int64(20),
+	})
 	assert.NoError(t, err)
 	sorted, err = filled.Sort(ctx, functions.Col("id").Asc())
 	assert.NoError(t, err)
 	res, err = sorted.Collect(ctx)
 	assert.NoError(t, err)
 	require.Equal(t, 2, len(res))
-	assert.Equal(t, []any{int64(0), int64(12), int64(20)}, res[0].Values())
+	assert.Equal(t, []any{nil, int64(12), int64(20)}, res[0].Values())
 	assert.Equal(t, []any{int64(1), int64(10), int64(1)}, res[1].Values())
-
-	// errors handling
-	_, err = df.FillNa(ctx, nil)
-	assert.Error(t, err)
-
-	_, err = df.FillNaWithValues(ctx, map[string]any{"int": nil})
-	assert.Error(t, err)
 }

--- a/internal/tests/integration/dataframe_test.go
+++ b/internal/tests/integration/dataframe_test.go
@@ -839,19 +839,19 @@ func TestDataFrame_FillNa(t *testing.T) {
 	res, err = sorted.Collect(ctx)
 	assert.NoError(t, err)
 	require.Equal(t, 2, len(res))
-	assert.Equal(t, []any{int64(1), int64(10), int64(1)}, res[0].Values())
-	assert.Equal(t, []any{nil, int64(12), int64(10)}, res[1].Values())
+	assert.Equal(t, []any{0, int64(12), int64(10)}, res[0].Values())
+	assert.Equal(t, []any{int64(1), int64(10), int64(1)}, res[1].Values())
 
 	// specific columns with map
-	filled, err = df.FillNa(ctx, map[string]any{"int": 10, "int2": 20})
+	filled, err = df.FillNaWithValues(ctx, map[string]any{"int": 10, "int2": 20})
 	assert.NoError(t, err)
 	sorted, err = filled.Sort(ctx, functions.Col("id").Asc())
 	assert.NoError(t, err)
 	res, err = sorted.Collect(ctx)
 	assert.NoError(t, err)
 	require.Equal(t, 2, len(res))
-	assert.Equal(t, []any{int64(1), int64(10), int64(1)}, res[0].Values())
-	assert.Equal(t, []any{nil, int64(12), int64(20)}, res[1].Values())
+	assert.Equal(t, []any{0, int64(12), int64(20)}, res[0].Values())
+	assert.Equal(t, []any{int64(1), int64(10), int64(1)}, res[1].Values())
 
 	// errors handling
 	_, err = df.FillNa(ctx, nil)

--- a/internal/tests/integration/dataframe_test.go
+++ b/internal/tests/integration/dataframe_test.go
@@ -839,7 +839,7 @@ func TestDataFrame_FillNa(t *testing.T) {
 	res, err = sorted.Collect(ctx)
 	assert.NoError(t, err)
 	require.Equal(t, 2, len(res))
-	assert.Equal(t, []any{0, int64(12), int64(10)}, res[0].Values())
+	assert.Equal(t, []any{int64(0), int64(12), int64(10)}, res[0].Values())
 	assert.Equal(t, []any{int64(1), int64(10), int64(1)}, res[1].Values())
 
 	// specific columns with map
@@ -850,7 +850,7 @@ func TestDataFrame_FillNa(t *testing.T) {
 	res, err = sorted.Collect(ctx)
 	assert.NoError(t, err)
 	require.Equal(t, 2, len(res))
-	assert.Equal(t, []any{0, int64(12), int64(20)}, res[0].Values())
+	assert.Equal(t, []any{int64(0), int64(12), int64(20)}, res[0].Values())
 	assert.Equal(t, []any{int64(1), int64(10), int64(1)}, res[1].Values())
 
 	// errors handling

--- a/internal/tests/integration/dataframe_test.go
+++ b/internal/tests/integration/dataframe_test.go
@@ -859,5 +859,4 @@ func TestDataFrame_FillNa(t *testing.T) {
 
 	_, err = df.FillNaWithValues(ctx, map[string]any{"int": nil})
 	assert.Error(t, err)
-
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR  adds `FillNa` and `FillNaWithValues` functions to `DataFrame`

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Added missing functions

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
