### PR TITLE
#95 Improve Compile-Time Safety for Literals

### DIFF
--- a/cmd/spark-connect-example-spark-session/main.go
+++ b/cmd/spark-connect-example-spark-session/main.go
@@ -20,8 +20,9 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"github.com/apache/spark-connect-go/v35/spark/sql/types"
 	"log"
+
+	"github.com/apache/spark-connect-go/v35/spark/sql/types"
 
 	"github.com/apache/spark-connect-go/v35/spark/sql/functions"
 

--- a/cmd/spark-connect-example-spark-session/main.go
+++ b/cmd/spark-connect-example-spark-session/main.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"github.com/apache/spark-connect-go/v35/spark/sql/types"
 	"log"
 
 	"github.com/apache/spark-connect-go/v35/spark/sql/functions"
@@ -68,7 +69,7 @@ func main() {
 	}
 
 	df, _ = spark.Sql(ctx, "select * from range(100)")
-	df, err = df.Filter(ctx, functions.Col("id").Lt(functions.Lit(20)))
+	df, err = df.Filter(ctx, functions.Col("id").Lt(functions.Lit(types.Int64(20))))
 	if err != nil {
 		log.Fatalf("Failed: %s", err)
 	}

--- a/dev/gen.py
+++ b/dev/gen.py
@@ -122,15 +122,15 @@ for fun in F.__dict__:
             args.append(p)
         elif param.annotation == str or typing.get_args(param.annotation) == (str, types.NoneType):
             res_params.append(f"{p} string")
-            conversions.append(f"lit_{p} := Lit({p})")
+            conversions.append(f"lit_{p} := StringLit({p})")
             args.append(f"lit_{p}")
         elif param.annotation == int or typing.get_args(param.annotation) == (int, types.NoneType):
             res_params.append(f"{p} int64")
-            conversions.append(f"lit_{p} := Lit({p})")
+            conversions.append(f"lit_{p} := Int64Lit({p})")
             args.append(f"lit_{p}")
         elif param.annotation == float or typing.get_args(param.annotation) == (float, types.NoneType):
             res_params.append(f"{p} float64")
-            conversions.append(f"lit_{p} := Lit({p})")
+            conversions.append(f"lit_{p} := Float64Lit({p})")
             args.append(f"lit_{p}")
         else:
             valid = False

--- a/internal/tests/integration/dataframe_test.go
+++ b/internal/tests/integration/dataframe_test.go
@@ -39,7 +39,7 @@ func TestDataFrame_Select(t *testing.T) {
 	assert.NoError(t, err)
 	df, err := spark.Sql(ctx, "select * from range(100)")
 	assert.NoError(t, err)
-	df, err = df.Select(ctx, functions.Lit("1"), functions.Lit("2"))
+	df, err = df.Select(ctx, functions.StringLit("1"), functions.StringLit("2"))
 	assert.NoError(t, err)
 
 	res, err := df.Collect(ctx)
@@ -210,7 +210,7 @@ func TestDataFrame_WithColumn(t *testing.T) {
 	ctx, spark := connect()
 	df, err := spark.Sql(ctx, "select * from range(10)")
 	assert.NoError(t, err)
-	df, err = df.WithColumn(ctx, "newCol", functions.Lit(1))
+	df, err = df.WithColumn(ctx, "newCol", functions.IntLit(1))
 	assert.NoError(t, err)
 	res, err := df.Collect(ctx)
 	assert.NoError(t, err)
@@ -226,8 +226,8 @@ func TestDataFrame_WithColumns(t *testing.T) {
 	ctx, spark := connect()
 	df, err := spark.Sql(ctx, "select * from range(10)")
 	assert.NoError(t, err)
-	df, err = df.WithColumns(ctx, column.WithAlias("newCol1", functions.Lit(1)),
-		column.WithAlias("newCol2", functions.Lit(2)))
+	df, err = df.WithColumns(ctx, column.WithAlias("newCol1", functions.IntLit(1)),
+		column.WithAlias("newCol2", functions.IntLit(2)))
 	assert.NoError(t, err)
 	res, err := df.Collect(ctx)
 	assert.NoError(t, err)
@@ -592,7 +592,7 @@ func TestDataFrame_Pivot(t *testing.T) {
 	df, err := spark.CreateDataFrame(ctx, data, schema)
 	assert.NoError(t, err)
 	gd := df.GroupBy(functions.Col("year"))
-	gd, err = gd.Pivot(ctx, "course", []any{"Java", "dotNET"})
+	gd, err = gd.Pivot(ctx, "course", []types.LiteralType{types.String("Java"), types.String("dotNET")})
 	assert.NoError(t, err)
 	df, err = gd.Sum(ctx, "earnings")
 	assert.NoError(t, err)

--- a/internal/tests/integration/functions_test.go
+++ b/internal/tests/integration/functions_test.go
@@ -33,7 +33,7 @@ func TestIntegration_BuiltinFunctions(t *testing.T) {
 	}
 
 	df, _ := spark.Sql(ctx, "select '[2]' as a from range(10)")
-	df, _ = df.Filter(ctx, functions.JsonArrayLength(functions.Col("a")).Eq(functions.Lit(1)))
+	df, _ = df.Filter(ctx, functions.JsonArrayLength(functions.Col("a")).Eq(functions.IntLit(1)))
 	res, err := df.Collect(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, 10, len(res))

--- a/internal/tests/integration/sql_test.go
+++ b/internal/tests/integration/sql_test.go
@@ -46,7 +46,7 @@ func TestIntegration_RunSQLCommand(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 100, len(res))
 
-	df, err = df.Filter(ctx, column.OfDF(df, "id").Lt(functions.Lit(10)))
+	df, err = df.Filter(ctx, column.OfDF(df, "id").Lt(functions.IntLit(10)))
 	assert.NoError(t, err)
 	res, err = df.Collect(ctx)
 	assert.NoErrorf(t, err, "Must be able to collect the rows.")

--- a/spark/sql/column/expressions.go
+++ b/spark/sql/column/expressions.go
@@ -18,8 +18,9 @@ package column
 import (
 	"context"
 	"fmt"
-	"github.com/apache/spark-connect-go/v35/spark/sql/types"
 	"strings"
+
+	"github.com/apache/spark-connect-go/v35/spark/sql/types"
 
 	"github.com/apache/spark-connect-go/v35/spark/sparkerrors"
 

--- a/spark/sql/column/expressions.go
+++ b/spark/sql/column/expressions.go
@@ -18,6 +18,7 @@ package column
 import (
 	"context"
 	"fmt"
+	"github.com/apache/spark-connect-go/v35/spark/sql/types"
 	"strings"
 
 	"github.com/apache/spark-connect-go/v35/spark/sparkerrors"
@@ -308,52 +309,17 @@ func (s *sqlExression) ToProto(context.Context) (*proto.Expression, error) {
 }
 
 type literalExpression struct {
-	value any
+	value types.LiteralType
 }
 
 func (l *literalExpression) DebugString() string {
 	return fmt.Sprintf("%v", l.value)
 }
 
-func (l *literalExpression) ToProto(context.Context) (*proto.Expression, error) {
-	expr := newProtoExpression()
-	expr.ExprType = &proto.Expression_Literal_{
-		Literal: &proto.Expression_Literal{},
-	}
-	switch v := l.value.(type) {
-	case int8:
-		expr.GetLiteral().LiteralType = &proto.Expression_Literal_Byte{Byte: int32(v)}
-	case int16:
-		expr.GetLiteral().LiteralType = &proto.Expression_Literal_Short{Short: int32(v)}
-	case int32:
-		expr.GetLiteral().LiteralType = &proto.Expression_Literal_Integer{Integer: v}
-	case int64:
-		expr.GetLiteral().LiteralType = &proto.Expression_Literal_Long{Long: v}
-	case uint8:
-		expr.GetLiteral().LiteralType = &proto.Expression_Literal_Short{Short: int32(v)}
-	case uint16:
-		expr.GetLiteral().LiteralType = &proto.Expression_Literal_Integer{Integer: int32(v)}
-	case uint32:
-		expr.GetLiteral().LiteralType = &proto.Expression_Literal_Long{Long: int64(v)}
-	case float32:
-		expr.GetLiteral().LiteralType = &proto.Expression_Literal_Float{Float: v}
-	case float64:
-		expr.GetLiteral().LiteralType = &proto.Expression_Literal_Double{Double: v}
-	case string:
-		expr.GetLiteral().LiteralType = &proto.Expression_Literal_String_{String_: v}
-	case bool:
-		expr.GetLiteral().LiteralType = &proto.Expression_Literal_Boolean{Boolean: v}
-	case []byte:
-		expr.GetLiteral().LiteralType = &proto.Expression_Literal_Binary{Binary: v}
-	case int:
-		expr.GetLiteral().LiteralType = &proto.Expression_Literal_Long{Long: int64(v)}
-	default:
-		return nil, sparkerrors.WithType(sparkerrors.InvalidPlanError,
-			fmt.Errorf("unsupported literal type %T", v))
-	}
-	return expr, nil
+func (l *literalExpression) ToProto(ctx context.Context) (*proto.Expression, error) {
+	return l.value.ToProto(ctx)
 }
 
-func NewLiteral(value any) expression {
+func NewLiteral(value types.LiteralType) expression {
 	return &literalExpression{value: value}
 }

--- a/spark/sql/dataframe_test.go
+++ b/spark/sql/dataframe_test.go
@@ -41,7 +41,7 @@ func TestDataFrameImpl_GroupBy(t *testing.T) {
 
 	assert.Equal(t, gd.groupType, "groupby")
 
-	df, err := gd.Agg(ctx, functions.Count(functions.Lit(1)))
+	df, err := gd.Agg(ctx, functions.Count(functions.Int64Lit(1)))
 	assert.Nil(t, err)
 	impl := df.(*dataFrameImpl)
 	assert.NotNil(t, impl)

--- a/spark/sql/functions/buiitins.go
+++ b/spark/sql/functions/buiitins.go
@@ -17,6 +17,7 @@ package functions
 
 import (
 	"github.com/apache/spark-connect-go/v35/spark/sql/column"
+	"github.com/apache/spark-connect-go/v35/spark/sql/types"
 )
 
 func Expr(expr string) column.Column {
@@ -27,6 +28,46 @@ func Col(name string) column.Column {
 	return column.NewColumn(column.NewColumnReference(name))
 }
 
-func Lit(value any) column.Column {
+func Lit(value types.LiteralType) column.Column {
 	return column.NewColumn(column.NewLiteral(value))
+}
+
+func Int8Lit(value int8) column.Column {
+	return Lit(types.Int8(value))
+}
+
+func Int16Lit(value int16) column.Column {
+	return Lit(types.Int16(value))
+}
+
+func Int32Lit(value int32) column.Column {
+	return Lit(types.Int32(value))
+}
+
+func Int64Lit(value int64) column.Column {
+	return Lit(types.Int64(value))
+}
+
+func Float32Lit(value float32) column.Column {
+	return Lit(types.Float32(value))
+}
+
+func Float64Lit(value float64) column.Column {
+	return Lit(types.Float64(value))
+}
+
+func StringLit(value string) column.Column {
+	return Lit(types.String(value))
+}
+
+func BoolLit(value bool) column.Column {
+	return Lit(types.Boolean(value))
+}
+
+func BinaryLit(value []byte) column.Column {
+	return Lit(types.Binary(value))
+}
+
+func IntLit(value int) column.Column {
+	return Lit(types.Int(value))
 }

--- a/spark/sql/functions/generated.go
+++ b/spark/sql/functions/generated.go
@@ -1,3 +1,4 @@
+
 // Licensed to the Apache Software Foundation (ASF) under one or more
 // contributor license agreements.  See the NOTICE file distributed with
 // this work for additional information regarding copyright ownership.
@@ -15,22 +16,20 @@
 
 package functions
 
-import (
-	"github.com/apache/spark-connect-go/v35/spark/sql/column"
-)
+import "github.com/apache/spark-connect-go/v35/spark/sql/column"
 
 // BitwiseNOT - Computes bitwise not.
 //
 // BitwiseNOT is the Golang equivalent of bitwiseNOT: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func BitwiseNOT(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bitwiseNOT", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bitwiseNOT", col))
 }
 
 // BitwiseNot - Computes bitwise not.
 //
 // BitwiseNot is the Golang equivalent of bitwise_not: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func BitwiseNot(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bitwise_not", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bitwise_not", col))
 }
 
 // BitCount - Returns the number of bits that are set in the argument expr as an unsigned 64-bit integer,
@@ -38,7 +37,7 @@ func BitwiseNot(col column.Column) column.Column {
 //
 // BitCount is the Golang equivalent of bit_count: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func BitCount(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bit_count", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bit_count", col))
 }
 
 // BitGet - Returns the value of the bit (0 or 1) at the specified position.
@@ -47,7 +46,7 @@ func BitCount(col column.Column) column.Column {
 //
 // BitGet is the Golang equivalent of bit_get: (col: 'ColumnOrName', pos: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func BitGet(col column.Column, pos column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bit_get", col, pos))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bit_get", col, pos))
 }
 
 // Getbit - Returns the value of the bit (0 or 1) at the specified position.
@@ -56,7 +55,7 @@ func BitGet(col column.Column, pos column.Column) column.Column {
 //
 // Getbit is the Golang equivalent of getbit: (col: 'ColumnOrName', pos: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Getbit(col column.Column, pos column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("getbit", col, pos))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("getbit", col, pos))
 }
 
 // TODO: broadcast: (df: 'DataFrame') -> 'DataFrame'
@@ -65,9 +64,9 @@ func Getbit(col column.Column, pos column.Column) column.Column {
 //
 // Coalesce is the Golang equivalent of coalesce: (*cols: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Coalesce(cols ...column.Column) column.Column {
-	vals := make([]column.Column, 0)
-	vals = append(vals, cols...)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("coalesce", vals...))
+    vals := make([]column.Column, 0)
+    vals = append(vals, cols...)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("coalesce", vals...))
 }
 
 // Greatest - Returns the greatest value of the list of column names, skipping null values.
@@ -75,16 +74,16 @@ func Coalesce(cols ...column.Column) column.Column {
 //
 // Greatest is the Golang equivalent of greatest: (*cols: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Greatest(cols ...column.Column) column.Column {
-	vals := make([]column.Column, 0)
-	vals = append(vals, cols...)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("greatest", vals...))
+    vals := make([]column.Column, 0)
+    vals = append(vals, cols...)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("greatest", vals...))
 }
 
 // InputFileName - Creates a string column for the file name of the current Spark task.
 //
 // InputFileName is the Golang equivalent of input_file_name: () -> pyspark.sql.connect.column.Column
 func InputFileName() column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("input_file_name"))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("input_file_name", ))
 }
 
 // Least - Returns the least value of the list of column names, skipping null values.
@@ -92,27 +91,27 @@ func InputFileName() column.Column {
 //
 // Least is the Golang equivalent of least: (*cols: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Least(cols ...column.Column) column.Column {
-	vals := make([]column.Column, 0)
-	vals = append(vals, cols...)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("least", vals...))
+    vals := make([]column.Column, 0)
+    vals = append(vals, cols...)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("least", vals...))
 }
 
 // Isnan - An expression that returns true if the column is NaN.
 //
 // Isnan is the Golang equivalent of isnan: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Isnan(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("isnan", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("isnan", col))
 }
 
 // Isnull - An expression that returns true if the column is null.
 //
 // Isnull is the Golang equivalent of isnull: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Isnull(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("isnull", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("isnull", col))
 }
 
 // MonotonicallyIncreasingId - A column that generates monotonically increasing 64-bit integers.
-//
+// 
 // The generated ID is guaranteed to be monotonically increasing and unique, but not consecutive.
 // The current implementation puts the partition ID in the upper 31 bits, and the record number
 // within each partition in the lower 33 bits. The assumption is that the data frame has
@@ -120,16 +119,16 @@ func Isnull(col column.Column) column.Column {
 //
 // MonotonicallyIncreasingId is the Golang equivalent of monotonically_increasing_id: () -> pyspark.sql.connect.column.Column
 func MonotonicallyIncreasingId() column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("monotonically_increasing_id"))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("monotonically_increasing_id", ))
 }
 
 // Nanvl - Returns col1 if it is not NaN, or col2 if col1 is NaN.
-//
+// 
 // Both inputs should be floating point columns (:class:`DoubleType` or :class:`FloatType`).
 //
 // Nanvl is the Golang equivalent of nanvl: (col1: 'ColumnOrName', col2: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Nanvl(col1 column.Column, col2 column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("nanvl", col1, col2))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("nanvl", col1, col2))
 }
 
 // Rand - Generates a random column with independent and identically distributed (i.i.d.) samples
@@ -137,8 +136,8 @@ func Nanvl(col1 column.Column, col2 column.Column) column.Column {
 //
 // Rand is the Golang equivalent of rand: (seed: Optional[int] = None) -> pyspark.sql.connect.column.Column
 func Rand(seed int64) column.Column {
-	lit_seed := Lit(seed)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("rand", lit_seed))
+    lit_seed := Int64Lit(seed)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("rand", lit_seed))
 }
 
 // Randn - Generates a column with independent and identically distributed (i.i.d.) samples from
@@ -146,15 +145,15 @@ func Rand(seed int64) column.Column {
 //
 // Randn is the Golang equivalent of randn: (seed: Optional[int] = None) -> pyspark.sql.connect.column.Column
 func Randn(seed int64) column.Column {
-	lit_seed := Lit(seed)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("randn", lit_seed))
+    lit_seed := Int64Lit(seed)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("randn", lit_seed))
 }
 
 // SparkPartitionId - A column for partition ID.
 //
 // SparkPartitionId is the Golang equivalent of spark_partition_id: () -> pyspark.sql.connect.column.Column
 func SparkPartitionId() column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("spark_partition_id"))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("spark_partition_id", ))
 }
 
 // TODO: when: (condition: pyspark.sql.connect.column.Column, value: Any) -> pyspark.sql.connect.column.Column
@@ -163,7 +162,7 @@ func SparkPartitionId() column.Column {
 //
 // Asc is the Golang equivalent of asc: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Asc(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("asc", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("asc", col))
 }
 
 // AscNullsFirst - Returns a sort expression based on the ascending order of the given
@@ -171,7 +170,7 @@ func Asc(col column.Column) column.Column {
 //
 // AscNullsFirst is the Golang equivalent of asc_nulls_first: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func AscNullsFirst(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("asc_nulls_first", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("asc_nulls_first", col))
 }
 
 // AscNullsLast - Returns a sort expression based on the ascending order of the given
@@ -179,14 +178,14 @@ func AscNullsFirst(col column.Column) column.Column {
 //
 // AscNullsLast is the Golang equivalent of asc_nulls_last: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func AscNullsLast(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("asc_nulls_last", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("asc_nulls_last", col))
 }
 
 // Desc - Returns a sort expression based on the descending order of the given column name.
 //
 // Desc is the Golang equivalent of desc: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Desc(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("desc", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("desc", col))
 }
 
 // DescNullsFirst - Returns a sort expression based on the descending order of the given
@@ -194,7 +193,7 @@ func Desc(col column.Column) column.Column {
 //
 // DescNullsFirst is the Golang equivalent of desc_nulls_first: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func DescNullsFirst(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("desc_nulls_first", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("desc_nulls_first", col))
 }
 
 // DescNullsLast - Returns a sort expression based on the descending order of the given
@@ -202,70 +201,70 @@ func DescNullsFirst(col column.Column) column.Column {
 //
 // DescNullsLast is the Golang equivalent of desc_nulls_last: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func DescNullsLast(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("desc_nulls_last", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("desc_nulls_last", col))
 }
 
 // Abs - Computes the absolute value.
 //
 // Abs is the Golang equivalent of abs: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Abs(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("abs", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("abs", col))
 }
 
 // Acos - Computes inverse cosine of the input column.
 //
 // Acos is the Golang equivalent of acos: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Acos(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("acos", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("acos", col))
 }
 
 // Acosh - Computes inverse hyperbolic cosine of the input column.
 //
 // Acosh is the Golang equivalent of acosh: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Acosh(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("acosh", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("acosh", col))
 }
 
 // Asin - Computes inverse sine of the input column.
 //
 // Asin is the Golang equivalent of asin: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Asin(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("asin", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("asin", col))
 }
 
 // Asinh - Computes inverse hyperbolic sine of the input column.
 //
 // Asinh is the Golang equivalent of asinh: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Asinh(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("asinh", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("asinh", col))
 }
 
 // Atan - Compute inverse tangent of the input column.
 //
 // Atan is the Golang equivalent of atan: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Atan(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("atan", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("atan", col))
 }
 
-// Atan2 -
+// Atan2 - 
 //
 // Atan2 is the Golang equivalent of atan2: (col1: Union[ForwardRef('ColumnOrName'), float], col2: Union[ForwardRef('ColumnOrName'), float]) -> pyspark.sql.connect.column.Column
 func Atan2(col1 column.Column, col2 column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("atan2", col1, col2))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("atan2", col1, col2))
 }
 
 // Atanh - Computes inverse hyperbolic tangent of the input column.
 //
 // Atanh is the Golang equivalent of atanh: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Atanh(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("atanh", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("atanh", col))
 }
 
 // Bin - Returns the string representation of the binary value of the given column.
 //
 // Bin is the Golang equivalent of bin: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Bin(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bin", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bin", col))
 }
 
 // Bround - Round the given value to `scale` decimal places using HALF_EVEN rounding mode if `scale` >= 0
@@ -273,66 +272,66 @@ func Bin(col column.Column) column.Column {
 //
 // Bround is the Golang equivalent of bround: (col: 'ColumnOrName', scale: int = 0) -> pyspark.sql.connect.column.Column
 func Bround(col column.Column, scale int64) column.Column {
-	lit_scale := Lit(scale)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bround", col, lit_scale))
+    lit_scale := Int64Lit(scale)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bround", col, lit_scale))
 }
 
 // Cbrt - Computes the cube-root of the given value.
 //
 // Cbrt is the Golang equivalent of cbrt: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Cbrt(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("cbrt", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("cbrt", col))
 }
 
 // Ceil - Computes the ceiling of the given value.
 //
 // Ceil is the Golang equivalent of ceil: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Ceil(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("ceil", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("ceil", col))
 }
 
 // Ceiling - Computes the ceiling of the given value.
 //
 // Ceiling is the Golang equivalent of ceiling: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Ceiling(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("ceiling", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("ceiling", col))
 }
 
 // Conv - Convert a number in a string column from one base to another.
 //
 // Conv is the Golang equivalent of conv: (col: 'ColumnOrName', fromBase: int, toBase: int) -> pyspark.sql.connect.column.Column
 func Conv(col column.Column, fromBase int64, toBase int64) column.Column {
-	lit_fromBase := Lit(fromBase)
-	lit_toBase := Lit(toBase)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("conv", col, lit_fromBase, lit_toBase))
+    lit_fromBase := Int64Lit(fromBase)
+    lit_toBase := Int64Lit(toBase)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("conv", col, lit_fromBase, lit_toBase))
 }
 
 // Cos - Computes cosine of the input column.
 //
 // Cos is the Golang equivalent of cos: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Cos(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("cos", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("cos", col))
 }
 
 // Cosh - Computes hyperbolic cosine of the input column.
 //
 // Cosh is the Golang equivalent of cosh: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Cosh(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("cosh", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("cosh", col))
 }
 
 // Cot - Computes cotangent of the input column.
 //
 // Cot is the Golang equivalent of cot: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Cot(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("cot", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("cot", col))
 }
 
 // Csc - Computes cosecant of the input column.
 //
 // Csc is the Golang equivalent of csc: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Csc(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("csc", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("csc", col))
 }
 
 // Degrees - Converts an angle measured in radians to an approximately equivalent angle
@@ -340,42 +339,42 @@ func Csc(col column.Column) column.Column {
 //
 // Degrees is the Golang equivalent of degrees: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Degrees(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("degrees", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("degrees", col))
 }
 
 // E - Returns Euler's number.
 //
 // E is the Golang equivalent of e: () -> pyspark.sql.connect.column.Column
 func E() column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("e"))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("e", ))
 }
 
 // Exp - Computes the exponential of the given value.
 //
 // Exp is the Golang equivalent of exp: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Exp(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("exp", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("exp", col))
 }
 
 // Expm1 - Computes the exponential of the given value minus one.
 //
 // Expm1 is the Golang equivalent of expm1: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Expm1(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("expm1", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("expm1", col))
 }
 
 // Factorial - Computes the factorial of the given value.
 //
 // Factorial is the Golang equivalent of factorial: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Factorial(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("factorial", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("factorial", col))
 }
 
 // Floor - Computes the floor of the given value.
 //
 // Floor is the Golang equivalent of floor: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Floor(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("floor", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("floor", col))
 }
 
 // Hex - Computes hex value of the given column, which could be :class:`pyspark.sql.types.StringType`,
@@ -384,86 +383,86 @@ func Floor(col column.Column) column.Column {
 //
 // Hex is the Golang equivalent of hex: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Hex(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("hex", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("hex", col))
 }
 
-// Hypot - Computes “sqrt(a^2 + b^2)“ without intermediate overflow or underflow.
+// Hypot - Computes ``sqrt(a^2 + b^2)`` without intermediate overflow or underflow.
 //
 // Hypot is the Golang equivalent of hypot: (col1: Union[ForwardRef('ColumnOrName'), float], col2: Union[ForwardRef('ColumnOrName'), float]) -> pyspark.sql.connect.column.Column
 func Hypot(col1 column.Column, col2 column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("hypot", col1, col2))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("hypot", col1, col2))
 }
 
 // Log - Returns the first argument-based logarithm of the second argument.
-//
+// 
 // If there is only one argument, then this takes the natural logarithm of the argument.
 //
 // Log is the Golang equivalent of log: (arg1: Union[ForwardRef('ColumnOrName'), float], arg2: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
 func Log(arg1 column.Column, arg2 column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("log", arg1, arg2))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("log", arg1, arg2))
 }
 
 // Log10 - Computes the logarithm of the given value in Base 10.
 //
 // Log10 is the Golang equivalent of log10: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Log10(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("log10", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("log10", col))
 }
 
 // Log1p - Computes the natural logarithm of the "given value plus one".
 //
 // Log1p is the Golang equivalent of log1p: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Log1p(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("log1p", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("log1p", col))
 }
 
 // Ln - Returns the natural logarithm of the argument.
 //
 // Ln is the Golang equivalent of ln: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Ln(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("ln", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("ln", col))
 }
 
 // Log2 - Returns the base-2 logarithm of the argument.
 //
 // Log2 is the Golang equivalent of log2: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Log2(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("log2", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("log2", col))
 }
 
 // Negative - Returns the negative value.
 //
 // Negative is the Golang equivalent of negative: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Negative(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("negative", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("negative", col))
 }
 
 // Negate - Returns the negative value.
 //
 // Negate is the Golang equivalent of negate: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Negate(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("negate", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("negate", col))
 }
 
 // Pi - Returns Pi.
 //
 // Pi is the Golang equivalent of pi: () -> pyspark.sql.connect.column.Column
 func Pi() column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("pi"))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("pi", ))
 }
 
 // Positive - Returns the value.
 //
 // Positive is the Golang equivalent of positive: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Positive(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("positive", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("positive", col))
 }
 
 // Pmod - Returns the positive value of dividend mod divisor.
 //
 // Pmod is the Golang equivalent of pmod: (dividend: Union[ForwardRef('ColumnOrName'), float], divisor: Union[ForwardRef('ColumnOrName'), float]) -> pyspark.sql.connect.column.Column
 func Pmod(dividend column.Column, divisor column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("pmod", dividend, divisor))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("pmod", dividend, divisor))
 }
 
 // WidthBucket - Returns the bucket number into which the value of this expression would fall
@@ -472,14 +471,14 @@ func Pmod(dividend column.Column, divisor column.Column) column.Column {
 //
 // WidthBucket is the Golang equivalent of width_bucket: (v: 'ColumnOrName', min: 'ColumnOrName', max: 'ColumnOrName', numBucket: Union[ForwardRef('ColumnOrName'), int]) -> pyspark.sql.connect.column.Column
 func WidthBucket(v column.Column, min column.Column, max column.Column, numBucket column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("width_bucket", v, min, max, numBucket))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("width_bucket", v, min, max, numBucket))
 }
 
 // Pow - Returns the value of the first argument raised to the power of the second argument.
 //
 // Pow is the Golang equivalent of pow: (col1: Union[ForwardRef('ColumnOrName'), float], col2: Union[ForwardRef('ColumnOrName'), float]) -> pyspark.sql.connect.column.Column
 func Pow(col1 column.Column, col2 column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("pow", col1, col2))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("pow", col1, col2))
 }
 
 // Radians - Converts an angle measured in degrees to an approximately equivalent angle
@@ -487,7 +486,7 @@ func Pow(col1 column.Column, col2 column.Column) column.Column {
 //
 // Radians is the Golang equivalent of radians: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Radians(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("radians", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("radians", col))
 }
 
 // Rint - Returns the double value that is closest in value to the argument and
@@ -495,7 +494,7 @@ func Radians(col column.Column) column.Column {
 //
 // Rint is the Golang equivalent of rint: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Rint(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("rint", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("rint", col))
 }
 
 // Round - Round the given value to `scale` decimal places using HALF_UP rounding mode if `scale` >= 0
@@ -503,98 +502,98 @@ func Rint(col column.Column) column.Column {
 //
 // Round is the Golang equivalent of round: (col: 'ColumnOrName', scale: int = 0) -> pyspark.sql.connect.column.Column
 func Round(col column.Column, scale int64) column.Column {
-	lit_scale := Lit(scale)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("round", col, lit_scale))
+    lit_scale := Int64Lit(scale)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("round", col, lit_scale))
 }
 
 // Sec - Computes secant of the input column.
 //
 // Sec is the Golang equivalent of sec: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Sec(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sec", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sec", col))
 }
 
 // ShiftLeft - Shift the given value numBits left.
 //
 // ShiftLeft is the Golang equivalent of shiftLeft: (col: 'ColumnOrName', numBits: int) -> pyspark.sql.connect.column.Column
 func ShiftLeft(col column.Column, numBits int64) column.Column {
-	lit_numBits := Lit(numBits)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("shiftLeft", col, lit_numBits))
+    lit_numBits := Int64Lit(numBits)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("shiftLeft", col, lit_numBits))
 }
 
 // Shiftleft - Shift the given value numBits left.
 //
 // Shiftleft is the Golang equivalent of shiftleft: (col: 'ColumnOrName', numBits: int) -> pyspark.sql.connect.column.Column
 func Shiftleft(col column.Column, numBits int64) column.Column {
-	lit_numBits := Lit(numBits)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("shiftleft", col, lit_numBits))
+    lit_numBits := Int64Lit(numBits)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("shiftleft", col, lit_numBits))
 }
 
 // ShiftRight - (Signed) shift the given value numBits right.
 //
 // ShiftRight is the Golang equivalent of shiftRight: (col: 'ColumnOrName', numBits: int) -> pyspark.sql.connect.column.Column
 func ShiftRight(col column.Column, numBits int64) column.Column {
-	lit_numBits := Lit(numBits)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("shiftRight", col, lit_numBits))
+    lit_numBits := Int64Lit(numBits)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("shiftRight", col, lit_numBits))
 }
 
 // Shiftright - (Signed) shift the given value numBits right.
 //
 // Shiftright is the Golang equivalent of shiftright: (col: 'ColumnOrName', numBits: int) -> pyspark.sql.connect.column.Column
 func Shiftright(col column.Column, numBits int64) column.Column {
-	lit_numBits := Lit(numBits)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("shiftright", col, lit_numBits))
+    lit_numBits := Int64Lit(numBits)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("shiftright", col, lit_numBits))
 }
 
 // ShiftRightUnsigned - Unsigned shift the given value numBits right.
 //
 // ShiftRightUnsigned is the Golang equivalent of shiftRightUnsigned: (col: 'ColumnOrName', numBits: int) -> pyspark.sql.connect.column.Column
 func ShiftRightUnsigned(col column.Column, numBits int64) column.Column {
-	lit_numBits := Lit(numBits)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("shiftRightUnsigned", col, lit_numBits))
+    lit_numBits := Int64Lit(numBits)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("shiftRightUnsigned", col, lit_numBits))
 }
 
 // Shiftrightunsigned - Unsigned shift the given value numBits right.
 //
 // Shiftrightunsigned is the Golang equivalent of shiftrightunsigned: (col: 'ColumnOrName', numBits: int) -> pyspark.sql.connect.column.Column
 func Shiftrightunsigned(col column.Column, numBits int64) column.Column {
-	lit_numBits := Lit(numBits)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("shiftrightunsigned", col, lit_numBits))
+    lit_numBits := Int64Lit(numBits)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("shiftrightunsigned", col, lit_numBits))
 }
 
 // Signum - Computes the signum of the given value.
 //
 // Signum is the Golang equivalent of signum: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Signum(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("signum", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("signum", col))
 }
 
 // Sign - Computes the signum of the given value.
 //
 // Sign is the Golang equivalent of sign: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Sign(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sign", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sign", col))
 }
 
 // Sin - Computes sine of the input column.
 //
 // Sin is the Golang equivalent of sin: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Sin(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sin", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sin", col))
 }
 
 // Sinh - Computes hyperbolic sine of the input column.
 //
 // Sinh is the Golang equivalent of sinh: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Sinh(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sinh", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sinh", col))
 }
 
 // Sqrt - Computes the square root of the specified float value.
 //
 // Sqrt is the Golang equivalent of sqrt: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Sqrt(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sqrt", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sqrt", col))
 }
 
 // TryAdd - Returns the sum of `left`and `right` and the result is null on overflow.
@@ -602,14 +601,14 @@ func Sqrt(col column.Column) column.Column {
 //
 // TryAdd is the Golang equivalent of try_add: (left: 'ColumnOrName', right: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func TryAdd(left column.Column, right column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_add", left, right))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_add", left, right))
 }
 
 // TryAvg - Returns the mean calculated from values of a group and the result is null on overflow.
 //
 // TryAvg is the Golang equivalent of try_avg: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func TryAvg(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_avg", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_avg", col))
 }
 
 // TryDivide - Returns `dividend`/`divisor`. It always performs floating point division. Its result is
@@ -617,7 +616,7 @@ func TryAvg(col column.Column) column.Column {
 //
 // TryDivide is the Golang equivalent of try_divide: (left: 'ColumnOrName', right: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func TryDivide(left column.Column, right column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_divide", left, right))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_divide", left, right))
 }
 
 // TryMultiply - Returns `left`*`right` and the result is null on overflow. The acceptable input types are the
@@ -625,7 +624,7 @@ func TryDivide(left column.Column, right column.Column) column.Column {
 //
 // TryMultiply is the Golang equivalent of try_multiply: (left: 'ColumnOrName', right: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func TryMultiply(left column.Column, right column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_multiply", left, right))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_multiply", left, right))
 }
 
 // TrySubtract - Returns `left`-`right` and the result is null on overflow. The acceptable input types are the
@@ -633,42 +632,42 @@ func TryMultiply(left column.Column, right column.Column) column.Column {
 //
 // TrySubtract is the Golang equivalent of try_subtract: (left: 'ColumnOrName', right: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func TrySubtract(left column.Column, right column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_subtract", left, right))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_subtract", left, right))
 }
 
 // TrySum - Returns the sum calculated from values of a group and the result is null on overflow.
 //
 // TrySum is the Golang equivalent of try_sum: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func TrySum(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_sum", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_sum", col))
 }
 
 // Tan - Computes tangent of the input column.
 //
 // Tan is the Golang equivalent of tan: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Tan(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("tan", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("tan", col))
 }
 
 // Tanh - Computes hyperbolic tangent of the input column.
 //
 // Tanh is the Golang equivalent of tanh: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Tanh(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("tanh", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("tanh", col))
 }
 
-// ToDegrees -
+// ToDegrees - 
 //
 // ToDegrees is the Golang equivalent of toDegrees: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func ToDegrees(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("toDegrees", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("toDegrees", col))
 }
 
-// ToRadians -
+// ToRadians - 
 //
 // ToRadians is the Golang equivalent of toRadians: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func ToRadians(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("toRadians", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("toRadians", col))
 }
 
 // Unhex - Inverse of hex. Interprets each pair of characters as a hexadecimal number
@@ -676,7 +675,7 @@ func ToRadians(col column.Column) column.Column {
 //
 // Unhex is the Golang equivalent of unhex: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Unhex(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("unhex", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("unhex", col))
 }
 
 // ApproxCountDistinct - Aggregate function: returns a new :class:`~pyspark.sql.Column` for approximate distinct count
@@ -684,77 +683,77 @@ func Unhex(col column.Column) column.Column {
 //
 // ApproxCountDistinct is the Golang equivalent of approx_count_distinct: (col: 'ColumnOrName', rsd: Optional[float] = None) -> pyspark.sql.connect.column.Column
 func ApproxCountDistinct(col column.Column, rsd float64) column.Column {
-	lit_rsd := Lit(rsd)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("approx_count_distinct", col, lit_rsd))
+    lit_rsd := Float64Lit(rsd)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("approx_count_distinct", col, lit_rsd))
 }
 
 // Avg - Aggregate function: returns the average of the values in a group.
 //
 // Avg is the Golang equivalent of avg: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Avg(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("avg", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("avg", col))
 }
 
 // CollectList - Aggregate function: returns a list of objects with duplicates.
 //
 // CollectList is the Golang equivalent of collect_list: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func CollectList(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("collect_list", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("collect_list", col))
 }
 
 // ArrayAgg - Aggregate function: returns a list of objects with duplicates.
 //
 // ArrayAgg is the Golang equivalent of array_agg: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func ArrayAgg(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_agg", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_agg", col))
 }
 
 // CollectSet - Aggregate function: returns a set of objects with duplicate elements eliminated.
 //
 // CollectSet is the Golang equivalent of collect_set: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func CollectSet(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("collect_set", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("collect_set", col))
 }
 
 // Corr - Returns a new :class:`~pyspark.sql.Column` for the Pearson Correlation Coefficient for
-// “col1“ and “col2“.
+// ``col1`` and ``col2``.
 //
 // Corr is the Golang equivalent of corr: (col1: 'ColumnOrName', col2: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Corr(col1 column.Column, col2 column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("corr", col1, col2))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("corr", col1, col2))
 }
 
 // Count - Aggregate function: returns the number of items in a group.
 //
 // Count is the Golang equivalent of count: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Count(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("count", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("count", col))
 }
 
-// CountDistinct - Returns a new :class:`Column` for distinct count of “col“ or “cols“.
+// CountDistinct - Returns a new :class:`Column` for distinct count of ``col`` or ``cols``.
 //
 // CountDistinct is the Golang equivalent of count_distinct: (col: 'ColumnOrName', *cols: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func CountDistinct(col column.Column, cols ...column.Column) column.Column {
-	vals := make([]column.Column, 0)
-	vals = append(vals, col)
-	vals = append(vals, cols...)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("count_distinct", vals...))
+    vals := make([]column.Column, 0)
+    vals = append(vals, col)
+    vals = append(vals, cols...)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("count_distinct", vals...))
 }
 
-// CovarPop - Returns a new :class:`~pyspark.sql.Column` for the population covariance of “col1“ and
-// “col2“.
+// CovarPop - Returns a new :class:`~pyspark.sql.Column` for the population covariance of ``col1`` and
+// ``col2``.
 //
 // CovarPop is the Golang equivalent of covar_pop: (col1: 'ColumnOrName', col2: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func CovarPop(col1 column.Column, col2 column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("covar_pop", col1, col2))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("covar_pop", col1, col2))
 }
 
-// CovarSamp - Returns a new :class:`~pyspark.sql.Column` for the sample covariance of “col1“ and
-// “col2“.
+// CovarSamp - Returns a new :class:`~pyspark.sql.Column` for the sample covariance of ``col1`` and
+// ``col2``.
 //
 // CovarSamp is the Golang equivalent of covar_samp: (col1: 'ColumnOrName', col2: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func CovarSamp(col1 column.Column, col2 column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("covar_samp", col1, col2))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("covar_samp", col1, col2))
 }
 
 // TODO: first: (col: 'ColumnOrName', ignorenulls: bool = False) -> pyspark.sql.connect.column.Column
@@ -764,18 +763,18 @@ func CovarSamp(col1 column.Column, col2 column.Column) column.Column {
 //
 // Grouping is the Golang equivalent of grouping: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Grouping(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("grouping", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("grouping", col))
 }
 
 // GroupingId - Aggregate function: returns the level of grouping, equals to
-//
+// 
 // (grouping(c1) << (n-1)) + (grouping(c2) << (n-2)) + ... + grouping(cn)
 //
 // GroupingId is the Golang equivalent of grouping_id: (*cols: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func GroupingId(cols ...column.Column) column.Column {
-	vals := make([]column.Column, 0)
-	vals = append(vals, cols...)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("grouping_id", vals...))
+    vals := make([]column.Column, 0)
+    vals = append(vals, cols...)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("grouping_id", vals...))
 }
 
 // CountMinSketch - Returns a count-min sketch of a column with the given esp, confidence and seed.
@@ -785,14 +784,14 @@ func GroupingId(cols ...column.Column) column.Column {
 //
 // CountMinSketch is the Golang equivalent of count_min_sketch: (col: 'ColumnOrName', eps: 'ColumnOrName', confidence: 'ColumnOrName', seed: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func CountMinSketch(col column.Column, eps column.Column, confidence column.Column, seed column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("count_min_sketch", col, eps, confidence, seed))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("count_min_sketch", col, eps, confidence, seed))
 }
 
 // Kurtosis - Aggregate function: returns the kurtosis of the values in a group.
 //
 // Kurtosis is the Golang equivalent of kurtosis: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Kurtosis(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("kurtosis", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("kurtosis", col))
 }
 
 // TODO: last: (col: 'ColumnOrName', ignorenulls: bool = False) -> pyspark.sql.connect.column.Column
@@ -801,14 +800,14 @@ func Kurtosis(col column.Column) column.Column {
 //
 // Max is the Golang equivalent of max: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Max(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("max", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("max", col))
 }
 
 // MaxBy - Returns the value associated with the maximum value of ord.
 //
 // MaxBy is the Golang equivalent of max_by: (col: 'ColumnOrName', ord: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func MaxBy(col column.Column, ord column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("max_by", col, ord))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("max_by", col, ord))
 }
 
 // Mean - Aggregate function: returns the average of the values in a group.
@@ -816,35 +815,35 @@ func MaxBy(col column.Column, ord column.Column) column.Column {
 //
 // Mean is the Golang equivalent of mean: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Mean(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("mean", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("mean", col))
 }
 
 // Median - Returns the median of the values in a group.
 //
 // Median is the Golang equivalent of median: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Median(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("median", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("median", col))
 }
 
 // Min - Aggregate function: returns the minimum value of the expression in a group.
 //
 // Min is the Golang equivalent of min: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Min(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("min", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("min", col))
 }
 
 // MinBy - Returns the value associated with the minimum value of ord.
 //
 // MinBy is the Golang equivalent of min_by: (col: 'ColumnOrName', ord: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func MinBy(col column.Column, ord column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("min_by", col, ord))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("min_by", col, ord))
 }
 
 // Mode - Returns the most frequent value in a group.
 //
 // Mode is the Golang equivalent of mode: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Mode(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("mode", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("mode", col))
 }
 
 // TODO: percentile: (col: 'ColumnOrName', percentage: Union[pyspark.sql.connect.column.Column, float, List[float], Tuple[float]], frequency: Union[pyspark.sql.connect.column.Column, int] = 1) -> pyspark.sql.connect.column.Column
@@ -857,28 +856,28 @@ func Mode(col column.Column) column.Column {
 //
 // Product is the Golang equivalent of product: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Product(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("product", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("product", col))
 }
 
 // Skewness - Aggregate function: returns the skewness of the values in a group.
 //
 // Skewness is the Golang equivalent of skewness: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Skewness(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("skewness", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("skewness", col))
 }
 
 // Stddev - Aggregate function: alias for stddev_samp.
 //
 // Stddev is the Golang equivalent of stddev: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Stddev(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("stddev", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("stddev", col))
 }
 
 // Std - Aggregate function: alias for stddev_samp.
 //
 // Std is the Golang equivalent of std: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Std(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("std", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("std", col))
 }
 
 // StddevSamp - Aggregate function: returns the unbiased sample standard deviation of
@@ -886,7 +885,7 @@ func Std(col column.Column) column.Column {
 //
 // StddevSamp is the Golang equivalent of stddev_samp: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func StddevSamp(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("stddev_samp", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("stddev_samp", col))
 }
 
 // StddevPop - Aggregate function: returns population standard deviation of
@@ -894,28 +893,28 @@ func StddevSamp(col column.Column) column.Column {
 //
 // StddevPop is the Golang equivalent of stddev_pop: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func StddevPop(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("stddev_pop", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("stddev_pop", col))
 }
 
 // Sum - Aggregate function: returns the sum of all values in the expression.
 //
 // Sum is the Golang equivalent of sum: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Sum(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sum", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sum", col))
 }
 
 // SumDistinct - Aggregate function: returns the sum of distinct values in the expression.
 //
 // SumDistinct is the Golang equivalent of sum_distinct: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func SumDistinct(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sum_distinct", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sum_distinct", col))
 }
 
 // VarPop - Aggregate function: returns the population variance of the values in a group.
 //
 // VarPop is the Golang equivalent of var_pop: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func VarPop(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("var_pop", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("var_pop", col))
 }
 
 // RegrAvgx - Aggregate function: returns the average of the independent variable for non-null pairs
@@ -923,7 +922,7 @@ func VarPop(col column.Column) column.Column {
 //
 // RegrAvgx is the Golang equivalent of regr_avgx: (y: 'ColumnOrName', x: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func RegrAvgx(y column.Column, x column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regr_avgx", y, x))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regr_avgx", y, x))
 }
 
 // RegrAvgy - Aggregate function: returns the average of the dependent variable for non-null pairs
@@ -931,7 +930,7 @@ func RegrAvgx(y column.Column, x column.Column) column.Column {
 //
 // RegrAvgy is the Golang equivalent of regr_avgy: (y: 'ColumnOrName', x: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func RegrAvgy(y column.Column, x column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regr_avgy", y, x))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regr_avgy", y, x))
 }
 
 // RegrCount - Aggregate function: returns the number of non-null number pairs
@@ -939,7 +938,7 @@ func RegrAvgy(y column.Column, x column.Column) column.Column {
 //
 // RegrCount is the Golang equivalent of regr_count: (y: 'ColumnOrName', x: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func RegrCount(y column.Column, x column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regr_count", y, x))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regr_count", y, x))
 }
 
 // RegrIntercept - Aggregate function: returns the intercept of the univariate linear regression line
@@ -948,7 +947,7 @@ func RegrCount(y column.Column, x column.Column) column.Column {
 //
 // RegrIntercept is the Golang equivalent of regr_intercept: (y: 'ColumnOrName', x: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func RegrIntercept(y column.Column, x column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regr_intercept", y, x))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regr_intercept", y, x))
 }
 
 // RegrR2 - Aggregate function: returns the coefficient of determination for non-null pairs
@@ -956,7 +955,7 @@ func RegrIntercept(y column.Column, x column.Column) column.Column {
 //
 // RegrR2 is the Golang equivalent of regr_r2: (y: 'ColumnOrName', x: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func RegrR2(y column.Column, x column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regr_r2", y, x))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regr_r2", y, x))
 }
 
 // RegrSlope - Aggregate function: returns the slope of the linear regression line for non-null pairs
@@ -964,7 +963,7 @@ func RegrR2(y column.Column, x column.Column) column.Column {
 //
 // RegrSlope is the Golang equivalent of regr_slope: (y: 'ColumnOrName', x: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func RegrSlope(y column.Column, x column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regr_slope", y, x))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regr_slope", y, x))
 }
 
 // RegrSxx - Aggregate function: returns REGR_COUNT(y, x) * VAR_POP(x) for non-null pairs
@@ -972,7 +971,7 @@ func RegrSlope(y column.Column, x column.Column) column.Column {
 //
 // RegrSxx is the Golang equivalent of regr_sxx: (y: 'ColumnOrName', x: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func RegrSxx(y column.Column, x column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regr_sxx", y, x))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regr_sxx", y, x))
 }
 
 // RegrSxy - Aggregate function: returns REGR_COUNT(y, x) * COVAR_POP(y, x) for non-null pairs
@@ -980,7 +979,7 @@ func RegrSxx(y column.Column, x column.Column) column.Column {
 //
 // RegrSxy is the Golang equivalent of regr_sxy: (y: 'ColumnOrName', x: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func RegrSxy(y column.Column, x column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regr_sxy", y, x))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regr_sxy", y, x))
 }
 
 // RegrSyy - Aggregate function: returns REGR_COUNT(y, x) * VAR_POP(y) for non-null pairs
@@ -988,7 +987,7 @@ func RegrSxy(y column.Column, x column.Column) column.Column {
 //
 // RegrSyy is the Golang equivalent of regr_syy: (y: 'ColumnOrName', x: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func RegrSyy(y column.Column, x column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regr_syy", y, x))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regr_syy", y, x))
 }
 
 // VarSamp - Aggregate function: returns the unbiased sample variance of
@@ -996,63 +995,63 @@ func RegrSyy(y column.Column, x column.Column) column.Column {
 //
 // VarSamp is the Golang equivalent of var_samp: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func VarSamp(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("var_samp", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("var_samp", col))
 }
 
 // Variance - Aggregate function: alias for var_samp
 //
 // Variance is the Golang equivalent of variance: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Variance(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("variance", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("variance", col))
 }
 
 // Every - Aggregate function: returns true if all values of `col` are true.
 //
 // Every is the Golang equivalent of every: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Every(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("every", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("every", col))
 }
 
 // BoolAnd - Aggregate function: returns true if all values of `col` are true.
 //
 // BoolAnd is the Golang equivalent of bool_and: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func BoolAnd(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bool_and", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bool_and", col))
 }
 
 // Some - Aggregate function: returns true if at least one value of `col` is true.
 //
 // Some is the Golang equivalent of some: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Some(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("some", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("some", col))
 }
 
 // BoolOr - Aggregate function: returns true if at least one value of `col` is true.
 //
 // BoolOr is the Golang equivalent of bool_or: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func BoolOr(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bool_or", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bool_or", col))
 }
 
 // BitAnd - Aggregate function: returns the bitwise AND of all non-null input values, or null if none.
 //
 // BitAnd is the Golang equivalent of bit_and: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func BitAnd(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bit_and", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bit_and", col))
 }
 
 // BitOr - Aggregate function: returns the bitwise OR of all non-null input values, or null if none.
 //
 // BitOr is the Golang equivalent of bit_or: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func BitOr(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bit_or", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bit_or", col))
 }
 
 // BitXor - Aggregate function: returns the bitwise XOR of all non-null input values, or null if none.
 //
 // BitXor is the Golang equivalent of bit_xor: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func BitXor(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bit_xor", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bit_xor", col))
 }
 
 // CumeDist - Window function: returns the cumulative distribution of values within a window partition,
@@ -1060,22 +1059,22 @@ func BitXor(col column.Column) column.Column {
 //
 // CumeDist is the Golang equivalent of cume_dist: () -> pyspark.sql.connect.column.Column
 func CumeDist() column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("cume_dist"))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("cume_dist", ))
 }
 
 // DenseRank - Window function: returns the rank of rows within a window partition, without any gaps.
-//
+// 
 // The difference between rank and dense_rank is that dense_rank leaves no gaps in ranking
 // sequence when there are ties. That is, if you were ranking a competition using dense_rank
 // and had three people tie for second place, you would say that all three were in second
 // place and that the next person came in third. Rank would give me sequential numbers, making
 // the person that came in third place (after the ties) would register as coming in fifth.
-//
+// 
 // This is equivalent to the DENSE_RANK function in SQL.
 //
 // DenseRank is the Golang equivalent of dense_rank: () -> pyspark.sql.connect.column.Column
 func DenseRank() column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("dense_rank"))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("dense_rank", ))
 }
 
 // TODO: lag: (col: 'ColumnOrName', offset: int = 1, default: Optional[Any] = None) -> pyspark.sql.connect.column.Column
@@ -1094,7 +1093,7 @@ func DenseRank() column.Column {
 //
 // CountIf is the Golang equivalent of count_if: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func CountIf(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("count_if", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("count_if", col))
 }
 
 // HistogramNumeric - Computes a histogram on numeric 'col' using nb bins.
@@ -1110,49 +1109,49 @@ func CountIf(col column.Column) column.Column {
 //
 // HistogramNumeric is the Golang equivalent of histogram_numeric: (col: 'ColumnOrName', nBins: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func HistogramNumeric(col column.Column, nBins column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("histogram_numeric", col, nBins))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("histogram_numeric", col, nBins))
 }
 
 // Ntile - Window function: returns the ntile group id (from 1 to `n` inclusive)
 // in an ordered window partition. For example, if `n` is 4, the first
 // quarter of the rows will get value 1, the second quarter will get 2,
 // the third quarter will get 3, and the last quarter will get 4.
-//
+// 
 // This is equivalent to the NTILE function in SQL.
 //
 // Ntile is the Golang equivalent of ntile: (n: int) -> pyspark.sql.connect.column.Column
 func Ntile(n int64) column.Column {
-	lit_n := Lit(n)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("ntile", lit_n))
+    lit_n := Int64Lit(n)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("ntile", lit_n))
 }
 
 // PercentRank - Window function: returns the relative rank (i.e. percentile) of rows within a window partition.
 //
 // PercentRank is the Golang equivalent of percent_rank: () -> pyspark.sql.connect.column.Column
 func PercentRank() column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("percent_rank"))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("percent_rank", ))
 }
 
 // Rank - Window function: returns the rank of rows within a window partition.
-//
+// 
 // The difference between rank and dense_rank is that dense_rank leaves no gaps in ranking
 // sequence when there are ties. That is, if you were ranking a competition using dense_rank
 // and had three people tie for second place, you would say that all three were in second
 // place and that the next person came in third. Rank would give me sequential numbers, making
 // the person that came in third place (after the ties) would register as coming in fifth.
-//
+// 
 // This is equivalent to the RANK function in SQL.
 //
 // Rank is the Golang equivalent of rank: () -> pyspark.sql.connect.column.Column
 func Rank() column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("rank"))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("rank", ))
 }
 
 // RowNumber - Window function: returns a sequential number starting at 1 within a window partition.
 //
 // RowNumber is the Golang equivalent of row_number: () -> pyspark.sql.connect.column.Column
 func RowNumber() column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("row_number"))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("row_number", ))
 }
 
 // TODO: aggregate: (col: 'ColumnOrName', initialValue: 'ColumnOrName', merge: Callable[[pyspark.sql.connect.column.Column, pyspark.sql.connect.column.Column], pyspark.sql.connect.column.Column], finish: Optional[Callable[[pyspark.sql.connect.column.Column], pyspark.sql.connect.column.Column]] = None) -> pyspark.sql.connect.column.Column
@@ -1163,7 +1162,7 @@ func RowNumber() column.Column {
 //
 // Array is the Golang equivalent of array: (*cols: Union[ForwardRef('ColumnOrName'), List[ForwardRef('ColumnOrName')], Tuple[ForwardRef('ColumnOrName'), ...]]) -> pyspark.sql.connect.column.Column
 func Array(cols column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array", cols))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array", cols))
 }
 
 // TODO: array_append: (col: 'ColumnOrName', value: Any) -> pyspark.sql.connect.column.Column
@@ -1174,7 +1173,7 @@ func Array(cols column.Column) column.Column {
 //
 // ArrayDistinct is the Golang equivalent of array_distinct: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func ArrayDistinct(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_distinct", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_distinct", col))
 }
 
 // ArrayExcept - Collection function: returns an array of the elements in col1 but not in col2,
@@ -1182,7 +1181,7 @@ func ArrayDistinct(col column.Column) column.Column {
 //
 // ArrayExcept is the Golang equivalent of array_except: (col1: 'ColumnOrName', col2: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func ArrayExcept(col1 column.Column, col2 column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_except", col1, col2))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_except", col1, col2))
 }
 
 // TODO: array_insert: (arr: 'ColumnOrName', pos: Union[ForwardRef('ColumnOrName'), int], value: Any) -> pyspark.sql.connect.column.Column
@@ -1192,14 +1191,14 @@ func ArrayExcept(col1 column.Column, col2 column.Column) column.Column {
 //
 // ArrayIntersect is the Golang equivalent of array_intersect: (col1: 'ColumnOrName', col2: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func ArrayIntersect(col1 column.Column, col2 column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_intersect", col1, col2))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_intersect", col1, col2))
 }
 
 // ArrayCompact - Collection function: removes null values from the array.
 //
 // ArrayCompact is the Golang equivalent of array_compact: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func ArrayCompact(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_compact", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_compact", col))
 }
 
 // ArrayJoin - Concatenates the elements of `column` using the `delimiter`. Null values are replaced with
@@ -1207,37 +1206,37 @@ func ArrayCompact(col column.Column) column.Column {
 //
 // ArrayJoin is the Golang equivalent of array_join: (col: 'ColumnOrName', delimiter: str, null_replacement: Optional[str] = None) -> pyspark.sql.connect.column.Column
 func ArrayJoin(col column.Column, delimiter string, null_replacement string) column.Column {
-	lit_delimiter := Lit(delimiter)
-	lit_null_replacement := Lit(null_replacement)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_join", col, lit_delimiter, lit_null_replacement))
+    lit_delimiter := StringLit(delimiter)
+    lit_null_replacement := StringLit(null_replacement)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_join", col, lit_delimiter, lit_null_replacement))
 }
 
 // ArrayMax - Collection function: returns the maximum value of the array.
 //
 // ArrayMax is the Golang equivalent of array_max: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func ArrayMax(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_max", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_max", col))
 }
 
 // ArrayMin - Collection function: returns the minimum value of the array.
 //
 // ArrayMin is the Golang equivalent of array_min: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func ArrayMin(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_min", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_min", col))
 }
 
 // ArraySize - Returns the total number of elements in the array. The function returns null for null input.
 //
 // ArraySize is the Golang equivalent of array_size: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func ArraySize(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_size", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_size", col))
 }
 
 // Cardinality - Collection function: returns the length of the array or map stored in the column.
 //
 // Cardinality is the Golang equivalent of cardinality: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Cardinality(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("cardinality", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("cardinality", col))
 }
 
 // TODO: array_position: (col: 'ColumnOrName', value: Any) -> pyspark.sql.connect.column.Column
@@ -1250,7 +1249,7 @@ func Cardinality(col column.Column) column.Column {
 //
 // ArrayRepeat is the Golang equivalent of array_repeat: (col: 'ColumnOrName', count: Union[ForwardRef('ColumnOrName'), int]) -> pyspark.sql.connect.column.Column
 func ArrayRepeat(col column.Column, count column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_repeat", col, count))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_repeat", col, count))
 }
 
 // TODO: array_sort: (col: 'ColumnOrName', comparator: Optional[Callable[[pyspark.sql.connect.column.Column, pyspark.sql.connect.column.Column], pyspark.sql.connect.column.Column]] = None) -> pyspark.sql.connect.column.Column
@@ -1260,7 +1259,7 @@ func ArrayRepeat(col column.Column, count column.Column) column.Column {
 //
 // ArrayUnion is the Golang equivalent of array_union: (col1: 'ColumnOrName', col2: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func ArrayUnion(col1 column.Column, col2 column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_union", col1, col2))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_union", col1, col2))
 }
 
 // ArraysOverlap - Collection function: returns true if the arrays contain any common non-null element; if not,
@@ -1269,7 +1268,7 @@ func ArrayUnion(col1 column.Column, col2 column.Column) column.Column {
 //
 // ArraysOverlap is the Golang equivalent of arrays_overlap: (a1: 'ColumnOrName', a2: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func ArraysOverlap(a1 column.Column, a2 column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("arrays_overlap", a1, a2))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("arrays_overlap", a1, a2))
 }
 
 // ArraysZip - Collection function: Returns a merged array of structs in which the N-th struct contains all
@@ -1278,9 +1277,9 @@ func ArraysOverlap(a1 column.Column, a2 column.Column) column.Column {
 //
 // ArraysZip is the Golang equivalent of arrays_zip: (*cols: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func ArraysZip(cols ...column.Column) column.Column {
-	vals := make([]column.Column, 0)
-	vals = append(vals, cols...)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("arrays_zip", vals...))
+    vals := make([]column.Column, 0)
+    vals = append(vals, cols...)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("arrays_zip", vals...))
 }
 
 // Concat - Concatenates multiple input columns together into a single column.
@@ -1288,16 +1287,16 @@ func ArraysZip(cols ...column.Column) column.Column {
 //
 // Concat is the Golang equivalent of concat: (*cols: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Concat(cols ...column.Column) column.Column {
-	vals := make([]column.Column, 0)
-	vals = append(vals, cols...)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("concat", vals...))
+    vals := make([]column.Column, 0)
+    vals = append(vals, cols...)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("concat", vals...))
 }
 
 // CreateMap - Creates a new map column.
 //
 // CreateMap is the Golang equivalent of create_map: (*cols: Union[ForwardRef('ColumnOrName'), List[ForwardRef('ColumnOrName')], Tuple[ForwardRef('ColumnOrName'), ...]]) -> pyspark.sql.connect.column.Column
 func CreateMap(cols column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("create_map", cols))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("create_map", cols))
 }
 
 // TODO: element_at: (col: 'ColumnOrName', extraction: Any) -> pyspark.sql.connect.column.Column
@@ -1305,13 +1304,13 @@ func CreateMap(cols column.Column) column.Column {
 // TryElementAt - (array, index) - Returns element of array at given (1-based) index. If Index is 0, Spark will
 // throw an error. If index < 0, accesses elements from the last to the first. The function
 // always returns NULL if the index exceeds the length of the array.
-//
+// 
 // (map, key) - Returns value for given key. The function always returns NULL if the key is not
 // contained in the map.
 //
 // TryElementAt is the Golang equivalent of try_element_at: (col: 'ColumnOrName', extraction: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func TryElementAt(col column.Column, extraction column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_element_at", col, extraction))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_element_at", col, extraction))
 }
 
 // TODO: exists: (col: 'ColumnOrName', f: Callable[[pyspark.sql.connect.column.Column], pyspark.sql.connect.column.Column]) -> pyspark.sql.connect.column.Column
@@ -1322,7 +1321,7 @@ func TryElementAt(col column.Column, extraction column.Column) column.Column {
 //
 // Explode is the Golang equivalent of explode: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Explode(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("explode", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("explode", col))
 }
 
 // ExplodeOuter - Returns a new row for each element in the given array or map.
@@ -1332,7 +1331,7 @@ func Explode(col column.Column) column.Column {
 //
 // ExplodeOuter is the Golang equivalent of explode_outer: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func ExplodeOuter(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("explode_outer", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("explode_outer", col))
 }
 
 // TODO: filter: (col: 'ColumnOrName', f: Union[Callable[[pyspark.sql.connect.column.Column], pyspark.sql.connect.column.Column], Callable[[pyspark.sql.connect.column.Column, pyspark.sql.connect.column.Column], pyspark.sql.connect.column.Column]]) -> pyspark.sql.connect.column.Column
@@ -1343,7 +1342,7 @@ func ExplodeOuter(col column.Column) column.Column {
 //
 // Flatten is the Golang equivalent of flatten: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Flatten(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("flatten", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("flatten", col))
 }
 
 // TODO: forall: (col: 'ColumnOrName', f: Callable[[pyspark.sql.connect.column.Column], pyspark.sql.connect.column.Column]) -> pyspark.sql.connect.column.Column
@@ -1358,7 +1357,7 @@ func Flatten(col column.Column) column.Column {
 //
 // Get is the Golang equivalent of get: (col: 'ColumnOrName', index: Union[ForwardRef('ColumnOrName'), int]) -> pyspark.sql.connect.column.Column
 func Get(col column.Column, index column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("get", col, index))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("get", col, index))
 }
 
 // GetJsonObject - Extracts json object from a json string based on json `path` specified, and returns json string
@@ -1366,8 +1365,8 @@ func Get(col column.Column, index column.Column) column.Column {
 //
 // GetJsonObject is the Golang equivalent of get_json_object: (col: 'ColumnOrName', path: str) -> pyspark.sql.connect.column.Column
 func GetJsonObject(col column.Column, path string) column.Column {
-	lit_path := Lit(path)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("get_json_object", col, lit_path))
+    lit_path := StringLit(path)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("get_json_object", col, lit_path))
 }
 
 // JsonArrayLength - Returns the number of elements in the outermost JSON array. `NULL` is returned in case of
@@ -1375,7 +1374,7 @@ func GetJsonObject(col column.Column, path string) column.Column {
 //
 // JsonArrayLength is the Golang equivalent of json_array_length: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func JsonArrayLength(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("json_array_length", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("json_array_length", col))
 }
 
 // JsonObjectKeys - Returns all the keys of the outermost JSON object as an array. If a valid JSON object is
@@ -1384,14 +1383,14 @@ func JsonArrayLength(col column.Column) column.Column {
 //
 // JsonObjectKeys is the Golang equivalent of json_object_keys: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func JsonObjectKeys(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("json_object_keys", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("json_object_keys", col))
 }
 
 // Inline - Explodes an array of structs into a table.
 //
 // Inline is the Golang equivalent of inline: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Inline(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("inline", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("inline", col))
 }
 
 // InlineOuter - Explodes an array of structs into a table.
@@ -1399,22 +1398,22 @@ func Inline(col column.Column) column.Column {
 //
 // InlineOuter is the Golang equivalent of inline_outer: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func InlineOuter(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("inline_outer", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("inline_outer", col))
 }
 
 // JsonTuple - Creates a new row for a json column according to the given field names.
 //
 // JsonTuple is the Golang equivalent of json_tuple: (col: 'ColumnOrName', *fields: str) -> pyspark.sql.connect.column.Column
 func JsonTuple(col column.Column, fields string) column.Column {
-	lit_fields := Lit(fields)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("json_tuple", col, lit_fields))
+    lit_fields := StringLit(fields)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("json_tuple", col, lit_fields))
 }
 
 // MapConcat - Returns the union of all the given maps.
 //
 // MapConcat is the Golang equivalent of map_concat: (*cols: Union[ForwardRef('ColumnOrName'), List[ForwardRef('ColumnOrName')], Tuple[ForwardRef('ColumnOrName'), ...]]) -> pyspark.sql.connect.column.Column
 func MapConcat(cols column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("map_concat", cols))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("map_concat", cols))
 }
 
 // TODO: map_contains_key: (col: 'ColumnOrName', value: Any) -> pyspark.sql.connect.column.Column
@@ -1423,7 +1422,7 @@ func MapConcat(cols column.Column) column.Column {
 //
 // MapEntries is the Golang equivalent of map_entries: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func MapEntries(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("map_entries", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("map_entries", col))
 }
 
 // TODO: map_filter: (col: 'ColumnOrName', f: Callable[[pyspark.sql.connect.column.Column, pyspark.sql.connect.column.Column], pyspark.sql.connect.column.Column]) -> pyspark.sql.connect.column.Column
@@ -1432,7 +1431,7 @@ func MapEntries(col column.Column) column.Column {
 //
 // MapFromArrays is the Golang equivalent of map_from_arrays: (col1: 'ColumnOrName', col2: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func MapFromArrays(col1 column.Column, col2 column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("map_from_arrays", col1, col2))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("map_from_arrays", col1, col2))
 }
 
 // MapFromEntries - Collection function: Converts an array of entries (key value struct types) to a map
@@ -1440,21 +1439,21 @@ func MapFromArrays(col1 column.Column, col2 column.Column) column.Column {
 //
 // MapFromEntries is the Golang equivalent of map_from_entries: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func MapFromEntries(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("map_from_entries", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("map_from_entries", col))
 }
 
 // MapKeys - Collection function: Returns an unordered array containing the keys of the map.
 //
 // MapKeys is the Golang equivalent of map_keys: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func MapKeys(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("map_keys", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("map_keys", col))
 }
 
 // MapValues - Collection function: Returns an unordered array containing the values of the map.
 //
 // MapValues is the Golang equivalent of map_values: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func MapValues(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("map_values", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("map_values", col))
 }
 
 // TODO: map_zip_with: (col1: 'ColumnOrName', col2: 'ColumnOrName', f: Callable[[pyspark.sql.connect.column.Column, pyspark.sql.connect.column.Column, pyspark.sql.connect.column.Column], pyspark.sql.connect.column.Column]) -> pyspark.sql.connect.column.Column
@@ -1464,7 +1463,7 @@ func MapValues(col column.Column) column.Column {
 //
 // StrToMap is the Golang equivalent of str_to_map: (text: 'ColumnOrName', pairDelim: Optional[ForwardRef('ColumnOrName')] = None, keyValueDelim: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
 func StrToMap(text column.Column, pairDelim column.Column, keyValueDelim column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("str_to_map", text, pairDelim, keyValueDelim))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("str_to_map", text, pairDelim, keyValueDelim))
 }
 
 // Posexplode - Returns a new row for each element with position in the given array or map.
@@ -1473,7 +1472,7 @@ func StrToMap(text column.Column, pairDelim column.Column, keyValueDelim column.
 //
 // Posexplode is the Golang equivalent of posexplode: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Posexplode(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("posexplode", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("posexplode", col))
 }
 
 // PosexplodeOuter - Returns a new row for each element with position in the given array or map.
@@ -1483,14 +1482,14 @@ func Posexplode(col column.Column) column.Column {
 //
 // PosexplodeOuter is the Golang equivalent of posexplode_outer: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func PosexplodeOuter(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("posexplode_outer", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("posexplode_outer", col))
 }
 
 // Reverse - Collection function: returns a reversed string or an array with reverse order of elements.
 //
 // Reverse is the Golang equivalent of reverse: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Reverse(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("reverse", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("reverse", col))
 }
 
 // Sequence - Generate a sequence of integers from `start` to `stop`, incrementing by `step`.
@@ -1499,7 +1498,7 @@ func Reverse(col column.Column) column.Column {
 //
 // Sequence is the Golang equivalent of sequence: (start: 'ColumnOrName', stop: 'ColumnOrName', step: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
 func Sequence(start column.Column, stop column.Column, step column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sequence", start, stop, step))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sequence", start, stop, step))
 }
 
 // TODO: schema_of_csv: (csv: 'ColumnOrName', options: Optional[Dict[str, str]] = None) -> pyspark.sql.connect.column.Column
@@ -1510,14 +1509,14 @@ func Sequence(start column.Column, stop column.Column, step column.Column) colum
 //
 // Shuffle is the Golang equivalent of shuffle: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Shuffle(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("shuffle", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("shuffle", col))
 }
 
 // Size - Collection function: returns the length of the array or map stored in the column.
 //
 // Size is the Golang equivalent of size: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Size(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("size", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("size", col))
 }
 
 // Slice - Collection function: returns an array containing all the elements in `x` from index `start`
@@ -1525,7 +1524,7 @@ func Size(col column.Column) column.Column {
 //
 // Slice is the Golang equivalent of slice: (col: 'ColumnOrName', start: Union[ForwardRef('ColumnOrName'), int], length: Union[ForwardRef('ColumnOrName'), int]) -> pyspark.sql.connect.column.Column
 func Slice(col column.Column, start column.Column, length column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("slice", col, start, length))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("slice", col, start, length))
 }
 
 // TODO: sort_array: (col: 'ColumnOrName', asc: bool = True) -> pyspark.sql.connect.column.Column
@@ -1534,16 +1533,16 @@ func Slice(col column.Column, start column.Column, length column.Column) column.
 //
 // Struct is the Golang equivalent of struct: (*cols: Union[ForwardRef('ColumnOrName'), List[ForwardRef('ColumnOrName')], Tuple[ForwardRef('ColumnOrName'), ...]]) -> pyspark.sql.connect.column.Column
 func Struct(cols column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("struct", cols))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("struct", cols))
 }
 
 // NamedStruct - Creates a struct with the given field names and values.
 //
 // NamedStruct is the Golang equivalent of named_struct: (*cols: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func NamedStruct(cols ...column.Column) column.Column {
-	vals := make([]column.Column, 0)
-	vals = append(vals, cols...)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("named_struct", vals...))
+    vals := make([]column.Column, 0)
+    vals = append(vals, cols...)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("named_struct", vals...))
 }
 
 // TODO: to_csv: (col: 'ColumnOrName', options: Optional[Dict[str, str]] = None) -> pyspark.sql.connect.column.Column
@@ -1562,56 +1561,56 @@ func NamedStruct(cols ...column.Column) column.Column {
 //
 // Upper is the Golang equivalent of upper: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Upper(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("upper", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("upper", col))
 }
 
 // Lower - Converts a string expression to lower case.
 //
 // Lower is the Golang equivalent of lower: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Lower(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("lower", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("lower", col))
 }
 
 // Ascii - Computes the numeric value of the first character of the string column.
 //
 // Ascii is the Golang equivalent of ascii: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Ascii(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("ascii", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("ascii", col))
 }
 
 // Base64 - Computes the BASE64 encoding of a binary column and returns it as a string column.
 //
 // Base64 is the Golang equivalent of base64: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Base64(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("base64", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("base64", col))
 }
 
 // Unbase64 - Decodes a BASE64 encoded string column and returns it as a binary column.
 //
 // Unbase64 is the Golang equivalent of unbase64: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Unbase64(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("unbase64", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("unbase64", col))
 }
 
 // Ltrim - Trim the spaces from left end for the specified string value.
 //
 // Ltrim is the Golang equivalent of ltrim: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Ltrim(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("ltrim", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("ltrim", col))
 }
 
 // Rtrim - Trim the spaces from right end for the specified string value.
 //
 // Rtrim is the Golang equivalent of rtrim: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Rtrim(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("rtrim", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("rtrim", col))
 }
 
 // Trim - Trim the spaces from both ends for the specified string column.
 //
 // Trim is the Golang equivalent of trim: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Trim(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("trim", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("trim", col))
 }
 
 // ConcatWs - Concatenates multiple input string columns together into a single string column,
@@ -1619,11 +1618,11 @@ func Trim(col column.Column) column.Column {
 //
 // ConcatWs is the Golang equivalent of concat_ws: (sep: str, *cols: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func ConcatWs(sep string, cols ...column.Column) column.Column {
-	lit_sep := Lit(sep)
-	vals := make([]column.Column, 0)
-	vals = append(vals, lit_sep)
-	vals = append(vals, cols...)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("concat_ws", vals...))
+    lit_sep := StringLit(sep)
+    vals := make([]column.Column, 0)
+    vals = append(vals, lit_sep)
+    vals = append(vals, cols...)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("concat_ws", vals...))
 }
 
 // Decode - Computes the first argument into a string from a binary using the provided character set
@@ -1631,8 +1630,8 @@ func ConcatWs(sep string, cols ...column.Column) column.Column {
 //
 // Decode is the Golang equivalent of decode: (col: 'ColumnOrName', charset: str) -> pyspark.sql.connect.column.Column
 func Decode(col column.Column, charset string) column.Column {
-	lit_charset := Lit(charset)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("decode", col, lit_charset))
+    lit_charset := StringLit(charset)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("decode", col, lit_charset))
 }
 
 // Encode - Computes the first argument into a binary from a string using the provided character set
@@ -1640,8 +1639,8 @@ func Decode(col column.Column, charset string) column.Column {
 //
 // Encode is the Golang equivalent of encode: (col: 'ColumnOrName', charset: str) -> pyspark.sql.connect.column.Column
 func Encode(col column.Column, charset string) column.Column {
-	lit_charset := Lit(charset)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("encode", col, lit_charset))
+    lit_charset := StringLit(charset)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("encode", col, lit_charset))
 }
 
 // FormatNumber - Formats the number X to a format like '#,--#,--#.--', rounded to d decimal places
@@ -1649,19 +1648,19 @@ func Encode(col column.Column, charset string) column.Column {
 //
 // FormatNumber is the Golang equivalent of format_number: (col: 'ColumnOrName', d: int) -> pyspark.sql.connect.column.Column
 func FormatNumber(col column.Column, d int64) column.Column {
-	lit_d := Lit(d)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("format_number", col, lit_d))
+    lit_d := Int64Lit(d)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("format_number", col, lit_d))
 }
 
 // FormatString - Formats the arguments in printf-style and returns the result as a string column.
 //
 // FormatString is the Golang equivalent of format_string: (format: str, *cols: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func FormatString(format string, cols ...column.Column) column.Column {
-	lit_format := Lit(format)
-	vals := make([]column.Column, 0)
-	vals = append(vals, lit_format)
-	vals = append(vals, cols...)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("format_string", vals...))
+    lit_format := StringLit(format)
+    vals := make([]column.Column, 0)
+    vals = append(vals, lit_format)
+    vals = append(vals, cols...)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("format_string", vals...))
 }
 
 // Instr - Locate the position of the first occurrence of substr column in the given string.
@@ -1669,8 +1668,8 @@ func FormatString(format string, cols ...column.Column) column.Column {
 //
 // Instr is the Golang equivalent of instr: (str: 'ColumnOrName', substr: str) -> pyspark.sql.connect.column.Column
 func Instr(str column.Column, substr string) column.Column {
-	lit_substr := Lit(substr)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("instr", str, lit_substr))
+    lit_substr := StringLit(substr)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("instr", str, lit_substr))
 }
 
 // Overlay - Overlay the specified portion of `src` with `replace`,
@@ -1678,7 +1677,7 @@ func Instr(str column.Column, substr string) column.Column {
 //
 // Overlay is the Golang equivalent of overlay: (src: 'ColumnOrName', replace: 'ColumnOrName', pos: Union[ForwardRef('ColumnOrName'), int], len: Union[ForwardRef('ColumnOrName'), int] = -1) -> pyspark.sql.connect.column.Column
 func Overlay(src column.Column, replace column.Column, pos column.Column, len column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("overlay", src, replace, pos, len))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("overlay", src, replace, pos, len))
 }
 
 // Sentences - Splits a string into arrays of sentences, where each sentence is an array of words.
@@ -1686,7 +1685,7 @@ func Overlay(src column.Column, replace column.Column, pos column.Column, len co
 //
 // Sentences is the Golang equivalent of sentences: (string: 'ColumnOrName', language: Optional[ForwardRef('ColumnOrName')] = None, country: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
 func Sentences(string column.Column, language column.Column, country column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sentences", string, language, country))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sentences", string, language, country))
 }
 
 // Substring - Substring starts at `pos` and is of length `len` when str is String type or
@@ -1695,9 +1694,9 @@ func Sentences(string column.Column, language column.Column, country column.Colu
 //
 // Substring is the Golang equivalent of substring: (str: 'ColumnOrName', pos: int, len: int) -> pyspark.sql.connect.column.Column
 func Substring(str column.Column, pos int64, len int64) column.Column {
-	lit_pos := Lit(pos)
-	lit_len := Lit(len)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("substring", str, lit_pos, lit_len))
+    lit_pos := Int64Lit(pos)
+    lit_len := Int64Lit(len)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("substring", str, lit_pos, lit_len))
 }
 
 // SubstringIndex - Returns the substring from string str before count occurrences of the delimiter delim.
@@ -1707,82 +1706,82 @@ func Substring(str column.Column, pos int64, len int64) column.Column {
 //
 // SubstringIndex is the Golang equivalent of substring_index: (str: 'ColumnOrName', delim: str, count: int) -> pyspark.sql.connect.column.Column
 func SubstringIndex(str column.Column, delim string, count int64) column.Column {
-	lit_delim := Lit(delim)
-	lit_count := Lit(count)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("substring_index", str, lit_delim, lit_count))
+    lit_delim := StringLit(delim)
+    lit_count := Int64Lit(count)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("substring_index", str, lit_delim, lit_count))
 }
 
 // Levenshtein - Computes the Levenshtein distance of the two given strings.
 //
 // Levenshtein is the Golang equivalent of levenshtein: (left: 'ColumnOrName', right: 'ColumnOrName', threshold: Optional[int] = None) -> pyspark.sql.connect.column.Column
 func Levenshtein(left column.Column, right column.Column, threshold int64) column.Column {
-	lit_threshold := Lit(threshold)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("levenshtein", left, right, lit_threshold))
+    lit_threshold := Int64Lit(threshold)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("levenshtein", left, right, lit_threshold))
 }
 
 // Locate - Locate the position of the first occurrence of substr in a string column, after position pos.
 //
 // Locate is the Golang equivalent of locate: (substr: str, str: 'ColumnOrName', pos: int = 1) -> pyspark.sql.connect.column.Column
 func Locate(substr string, str column.Column, pos int64) column.Column {
-	lit_substr := Lit(substr)
-	lit_pos := Lit(pos)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("locate", lit_substr, str, lit_pos))
+    lit_substr := StringLit(substr)
+    lit_pos := Int64Lit(pos)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("locate", lit_substr, str, lit_pos))
 }
 
 // Lpad - Left-pad the string column to width `len` with `pad`.
 //
 // Lpad is the Golang equivalent of lpad: (col: 'ColumnOrName', len: int, pad: str) -> pyspark.sql.connect.column.Column
 func Lpad(col column.Column, len int64, pad string) column.Column {
-	lit_len := Lit(len)
-	lit_pad := Lit(pad)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("lpad", col, lit_len, lit_pad))
+    lit_len := Int64Lit(len)
+    lit_pad := StringLit(pad)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("lpad", col, lit_len, lit_pad))
 }
 
 // Rpad - Right-pad the string column to width `len` with `pad`.
 //
 // Rpad is the Golang equivalent of rpad: (col: 'ColumnOrName', len: int, pad: str) -> pyspark.sql.connect.column.Column
 func Rpad(col column.Column, len int64, pad string) column.Column {
-	lit_len := Lit(len)
-	lit_pad := Lit(pad)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("rpad", col, lit_len, lit_pad))
+    lit_len := Int64Lit(len)
+    lit_pad := StringLit(pad)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("rpad", col, lit_len, lit_pad))
 }
 
 // Repeat - Repeats a string column n times, and returns it as a new string column.
 //
 // Repeat is the Golang equivalent of repeat: (col: 'ColumnOrName', n: int) -> pyspark.sql.connect.column.Column
 func Repeat(col column.Column, n int64) column.Column {
-	lit_n := Lit(n)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("repeat", col, lit_n))
+    lit_n := Int64Lit(n)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("repeat", col, lit_n))
 }
 
 // Split - Splits str around matches of the given pattern.
 //
 // Split is the Golang equivalent of split: (str: 'ColumnOrName', pattern: str, limit: int = -1) -> pyspark.sql.connect.column.Column
 func Split(str column.Column, pattern string, limit int64) column.Column {
-	lit_pattern := Lit(pattern)
-	lit_limit := Lit(limit)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("split", str, lit_pattern, lit_limit))
+    lit_pattern := StringLit(pattern)
+    lit_limit := Int64Lit(limit)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("split", str, lit_pattern, lit_limit))
 }
 
 // Rlike - Returns true if `str` matches the Java regex `regexp`, or false otherwise.
 //
 // Rlike is the Golang equivalent of rlike: (str: 'ColumnOrName', regexp: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Rlike(str column.Column, regexp column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("rlike", str, regexp))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("rlike", str, regexp))
 }
 
 // Regexp - Returns true if `str` matches the Java regex `regexp`, or false otherwise.
 //
 // Regexp is the Golang equivalent of regexp: (str: 'ColumnOrName', regexp: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Regexp(str column.Column, regexp column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regexp", str, regexp))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regexp", str, regexp))
 }
 
 // RegexpLike - Returns true if `str` matches the Java regex `regexp`, or false otherwise.
 //
 // RegexpLike is the Golang equivalent of regexp_like: (str: 'ColumnOrName', regexp: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func RegexpLike(str column.Column, regexp column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regexp_like", str, regexp))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regexp_like", str, regexp))
 }
 
 // RegexpCount - Returns a count of the number of times that the Java regex pattern `regexp` is matched
@@ -1790,7 +1789,7 @@ func RegexpLike(str column.Column, regexp column.Column) column.Column {
 //
 // RegexpCount is the Golang equivalent of regexp_count: (str: 'ColumnOrName', regexp: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func RegexpCount(str column.Column, regexp column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regexp_count", str, regexp))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regexp_count", str, regexp))
 }
 
 // RegexpExtract - Extract a specific group matched by the Java regex `regexp`, from the specified string column.
@@ -1798,9 +1797,9 @@ func RegexpCount(str column.Column, regexp column.Column) column.Column {
 //
 // RegexpExtract is the Golang equivalent of regexp_extract: (str: 'ColumnOrName', pattern: str, idx: int) -> pyspark.sql.connect.column.Column
 func RegexpExtract(str column.Column, pattern string, idx int64) column.Column {
-	lit_pattern := Lit(pattern)
-	lit_idx := Lit(idx)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regexp_extract", str, lit_pattern, lit_idx))
+    lit_pattern := StringLit(pattern)
+    lit_idx := Int64Lit(idx)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regexp_extract", str, lit_pattern, lit_idx))
 }
 
 // TODO: regexp_extract_all: (str: 'ColumnOrName', regexp: 'ColumnOrName', idx: Union[int, pyspark.sql.connect.column.Column, NoneType] = None) -> pyspark.sql.connect.column.Column
@@ -1812,7 +1811,7 @@ func RegexpExtract(str column.Column, pattern string, idx int64) column.Column {
 //
 // RegexpSubstr is the Golang equivalent of regexp_substr: (str: 'ColumnOrName', regexp: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func RegexpSubstr(str column.Column, regexp column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regexp_substr", str, regexp))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regexp_substr", str, regexp))
 }
 
 // TODO: regexp_instr: (str: 'ColumnOrName', regexp: 'ColumnOrName', idx: Union[int, pyspark.sql.connect.column.Column, NoneType] = None) -> pyspark.sql.connect.column.Column
@@ -1821,14 +1820,14 @@ func RegexpSubstr(str column.Column, regexp column.Column) column.Column {
 //
 // Initcap is the Golang equivalent of initcap: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Initcap(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("initcap", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("initcap", col))
 }
 
 // Soundex - Returns the SoundEx encoding for a string
 //
 // Soundex is the Golang equivalent of soundex: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Soundex(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("soundex", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("soundex", col))
 }
 
 // Length - Computes the character length of string data or number of bytes of binary data.
@@ -1837,21 +1836,21 @@ func Soundex(col column.Column) column.Column {
 //
 // Length is the Golang equivalent of length: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Length(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("length", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("length", col))
 }
 
 // OctetLength - Calculates the byte length for the specified string column.
 //
 // OctetLength is the Golang equivalent of octet_length: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func OctetLength(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("octet_length", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("octet_length", col))
 }
 
 // BitLength - Calculates the bit length for the specified string column.
 //
 // BitLength is the Golang equivalent of bit_length: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func BitLength(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bit_length", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bit_length", col))
 }
 
 // Translate - A function translate any character in the `srcCol` by a character in `matching`.
@@ -1861,9 +1860,9 @@ func BitLength(col column.Column) column.Column {
 //
 // Translate is the Golang equivalent of translate: (srcCol: 'ColumnOrName', matching: str, replace: str) -> pyspark.sql.connect.column.Column
 func Translate(srcCol column.Column, matching string, replace string) column.Column {
-	lit_matching := Lit(matching)
-	lit_replace := Lit(replace)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("translate", srcCol, lit_matching, lit_replace))
+    lit_matching := StringLit(matching)
+    lit_replace := StringLit(replace)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("translate", srcCol, lit_matching, lit_replace))
 }
 
 // ToBinary - Converts the input `col` to a binary value based on the supplied `format`.
@@ -1874,7 +1873,7 @@ func Translate(srcCol column.Column, matching string, replace string) column.Col
 //
 // ToBinary is the Golang equivalent of to_binary: (col: 'ColumnOrName', format: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
 func ToBinary(col column.Column, format column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("to_binary", col, format))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("to_binary", col, format))
 }
 
 // ToChar - Convert `col` to a string based on the `format`.
@@ -1898,7 +1897,7 @@ func ToBinary(col column.Column, format column.Column) column.Column {
 //
 // ToChar is the Golang equivalent of to_char: (col: 'ColumnOrName', format: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func ToChar(col column.Column, format column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("to_char", col, format))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("to_char", col, format))
 }
 
 // ToVarchar - Convert `col` to a string based on the `format`.
@@ -1922,7 +1921,7 @@ func ToChar(col column.Column, format column.Column) column.Column {
 //
 // ToVarchar is the Golang equivalent of to_varchar: (col: 'ColumnOrName', format: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func ToVarchar(col column.Column, format column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("to_varchar", col, format))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("to_varchar", col, format))
 }
 
 // ToNumber - Convert string 'col' to a number based on the string format 'format'.
@@ -1947,14 +1946,14 @@ func ToVarchar(col column.Column, format column.Column) column.Column {
 //
 // ToNumber is the Golang equivalent of to_number: (col: 'ColumnOrName', format: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func ToNumber(col column.Column, format column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("to_number", col, format))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("to_number", col, format))
 }
 
 // Replace - Replaces all occurrences of `search` with `replace`.
 //
 // Replace is the Golang equivalent of replace: (src: 'ColumnOrName', search: 'ColumnOrName', replace: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
 func Replace(src column.Column, search column.Column, replace column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("replace", src, search, replace))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("replace", src, search, replace))
 }
 
 // SplitPart - Splits `str` by delimiter and return requested part of the split (1-based).
@@ -1965,7 +1964,7 @@ func Replace(src column.Column, search column.Column, replace column.Column) col
 //
 // SplitPart is the Golang equivalent of split_part: (src: 'ColumnOrName', delimiter: 'ColumnOrName', partNum: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func SplitPart(src column.Column, delimiter column.Column, partNum column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("split_part", src, delimiter, partNum))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("split_part", src, delimiter, partNum))
 }
 
 // Substr - Returns the substring of `str` that starts at `pos` and is of length `len`,
@@ -1973,24 +1972,24 @@ func SplitPart(src column.Column, delimiter column.Column, partNum column.Column
 //
 // Substr is the Golang equivalent of substr: (str: 'ColumnOrName', pos: 'ColumnOrName', len: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
 func Substr(str column.Column, pos column.Column, len column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("substr", str, pos, len))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("substr", str, pos, len))
 }
 
 // ParseUrl - Extracts a part from a URL.
 //
 // ParseUrl is the Golang equivalent of parse_url: (url: 'ColumnOrName', partToExtract: 'ColumnOrName', key: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
 func ParseUrl(url column.Column, partToExtract column.Column, key column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("parse_url", url, partToExtract, key))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("parse_url", url, partToExtract, key))
 }
 
 // Printf - Formats the arguments in printf-style and returns the result as a string column.
 //
 // Printf is the Golang equivalent of printf: (format: 'ColumnOrName', *cols: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Printf(format column.Column, cols ...column.Column) column.Column {
-	vals := make([]column.Column, 0)
-	vals = append(vals, format)
-	vals = append(vals, cols...)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("printf", vals...))
+    vals := make([]column.Column, 0)
+    vals = append(vals, format)
+    vals = append(vals, cols...)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("printf", vals...))
 }
 
 // UrlDecode - Decodes a `str` in 'application/x-www-form-urlencoded' format
@@ -1998,7 +1997,7 @@ func Printf(format column.Column, cols ...column.Column) column.Column {
 //
 // UrlDecode is the Golang equivalent of url_decode: (str: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func UrlDecode(str column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("url_decode", str))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("url_decode", str))
 }
 
 // UrlEncode - Translates a string into 'application/x-www-form-urlencoded' format
@@ -2006,7 +2005,7 @@ func UrlDecode(str column.Column) column.Column {
 //
 // UrlEncode is the Golang equivalent of url_encode: (str: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func UrlEncode(str column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("url_encode", str))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("url_encode", str))
 }
 
 // Position - Returns the position of the first occurrence of `substr` in `str` after position `start`.
@@ -2014,7 +2013,7 @@ func UrlEncode(str column.Column) column.Column {
 //
 // Position is the Golang equivalent of position: (substr: 'ColumnOrName', str: 'ColumnOrName', start: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
 func Position(substr column.Column, str column.Column, start column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("position", substr, str, start))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("position", substr, str, start))
 }
 
 // Endswith - Returns a boolean. The value is True if str ends with suffix.
@@ -2023,7 +2022,7 @@ func Position(substr column.Column, str column.Column, start column.Column) colu
 //
 // Endswith is the Golang equivalent of endswith: (str: 'ColumnOrName', suffix: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Endswith(str column.Column, suffix column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("endswith", str, suffix))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("endswith", str, suffix))
 }
 
 // Startswith - Returns a boolean. The value is True if str starts with prefix.
@@ -2032,7 +2031,7 @@ func Endswith(str column.Column, suffix column.Column) column.Column {
 //
 // Startswith is the Golang equivalent of startswith: (str: 'ColumnOrName', prefix: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Startswith(str column.Column, prefix column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("startswith", str, prefix))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("startswith", str, prefix))
 }
 
 // Char - Returns the ASCII character having the binary equivalent to `col`. If col is larger than 256 the
@@ -2040,7 +2039,7 @@ func Startswith(str column.Column, prefix column.Column) column.Column {
 //
 // Char is the Golang equivalent of char: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Char(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("char", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("char", col))
 }
 
 // TryToBinary - This is a special version of `to_binary` that performs the same operation, but returns a NULL
@@ -2048,7 +2047,7 @@ func Char(col column.Column) column.Column {
 //
 // TryToBinary is the Golang equivalent of try_to_binary: (col: 'ColumnOrName', format: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
 func TryToBinary(col column.Column, format column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_to_binary", col, format))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_to_binary", col, format))
 }
 
 // TryToNumber - Convert string 'col' to a number based on the string format `format`. Returns NULL if the
@@ -2057,14 +2056,14 @@ func TryToBinary(col column.Column, format column.Column) column.Column {
 //
 // TryToNumber is the Golang equivalent of try_to_number: (col: 'ColumnOrName', format: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func TryToNumber(col column.Column, format column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_to_number", col, format))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_to_number", col, format))
 }
 
 // Btrim - Remove the leading and trailing `trim` characters from `str`.
 //
 // Btrim is the Golang equivalent of btrim: (str: 'ColumnOrName', trim: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
 func Btrim(str column.Column, trim column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("btrim", str, trim))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("btrim", str, trim))
 }
 
 // CharLength - Returns the character length of string data or number of bytes of binary data.
@@ -2073,7 +2072,7 @@ func Btrim(str column.Column, trim column.Column) column.Column {
 //
 // CharLength is the Golang equivalent of char_length: (str: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func CharLength(str column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("char_length", str))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("char_length", str))
 }
 
 // CharacterLength - Returns the character length of string data or number of bytes of binary data.
@@ -2082,7 +2081,7 @@ func CharLength(str column.Column) column.Column {
 //
 // CharacterLength is the Golang equivalent of character_length: (str: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func CharacterLength(str column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("character_length", str))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("character_length", str))
 }
 
 // Contains - Returns a boolean. The value is True if right is found inside left.
@@ -2091,7 +2090,7 @@ func CharacterLength(str column.Column) column.Column {
 //
 // Contains is the Golang equivalent of contains: (left: 'ColumnOrName', right: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Contains(left column.Column, right column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("contains", left, right))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("contains", left, right))
 }
 
 // Elt - Returns the `n`-th input, e.g., returns `input2` when `n` is 2.
@@ -2101,9 +2100,9 @@ func Contains(left column.Column, right column.Column) column.Column {
 //
 // Elt is the Golang equivalent of elt: (*inputs: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Elt(inputs ...column.Column) column.Column {
-	vals := make([]column.Column, 0)
-	vals = append(vals, inputs...)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("elt", vals...))
+    vals := make([]column.Column, 0)
+    vals = append(vals, inputs...)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("elt", vals...))
 }
 
 // FindInSet - Returns the index (1-based) of the given string (`str`) in the comma-delimited
@@ -2112,7 +2111,7 @@ func Elt(inputs ...column.Column) column.Column {
 //
 // FindInSet is the Golang equivalent of find_in_set: (str: 'ColumnOrName', str_array: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func FindInSet(str column.Column, str_array column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("find_in_set", str, str_array))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("find_in_set", str, str_array))
 }
 
 // TODO: like: (str: 'ColumnOrName', pattern: 'ColumnOrName', escapeChar: Optional[ForwardRef('Column')] = None) -> pyspark.sql.connect.column.Column
@@ -2123,14 +2122,14 @@ func FindInSet(str column.Column, str_array column.Column) column.Column {
 //
 // Lcase is the Golang equivalent of lcase: (str: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Lcase(str column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("lcase", str))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("lcase", str))
 }
 
 // Ucase - Returns `str` with all characters changed to uppercase.
 //
 // Ucase is the Golang equivalent of ucase: (str: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Ucase(str column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("ucase", str))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("ucase", str))
 }
 
 // Left - Returns the leftmost `len`(`len` can be string type) characters from the string `str`,
@@ -2138,7 +2137,7 @@ func Ucase(str column.Column) column.Column {
 //
 // Left is the Golang equivalent of left: (str: 'ColumnOrName', len: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Left(str column.Column, len column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("left", str, len))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("left", str, len))
 }
 
 // Right - Returns the rightmost `len`(`len` can be string type) characters from the string `str`,
@@ -2146,17 +2145,15 @@ func Left(str column.Column, len column.Column) column.Column {
 //
 // Right is the Golang equivalent of right: (str: 'ColumnOrName', len: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Right(str column.Column, len column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("right", str, len))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("right", str, len))
 }
 
 // Mask - Masks the given string value. This can be useful for creating copies of tables with sensitive
 // information removed.
 //
 // Mask is the Golang equivalent of mask: (col: 'ColumnOrName', upperChar: Optional[ForwardRef('ColumnOrName')] = None, lowerChar: Optional[ForwardRef('ColumnOrName')] = None, digitChar: Optional[ForwardRef('ColumnOrName')] = None, otherChar: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
-func Mask(col column.Column, upperChar column.Column, lowerChar column.Column,
-	digitChar column.Column, otherChar column.Column,
-) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("mask", col, upperChar, lowerChar, digitChar, otherChar))
+func Mask(col column.Column, upperChar column.Column, lowerChar column.Column, digitChar column.Column, otherChar column.Column) column.Column {
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("mask", col, upperChar, lowerChar, digitChar, otherChar))
 }
 
 // Curdate - Returns the current date at the start of query evaluation as a :class:`DateType` column.
@@ -2164,7 +2161,7 @@ func Mask(col column.Column, upperChar column.Column, lowerChar column.Column,
 //
 // Curdate is the Golang equivalent of curdate: () -> pyspark.sql.connect.column.Column
 func Curdate() column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("curdate"))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("curdate", ))
 }
 
 // CurrentDate - Returns the current date at the start of query evaluation as a :class:`DateType` column.
@@ -2172,7 +2169,7 @@ func Curdate() column.Column {
 //
 // CurrentDate is the Golang equivalent of current_date: () -> pyspark.sql.connect.column.Column
 func CurrentDate() column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("current_date"))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("current_date", ))
 }
 
 // CurrentTimestamp - Returns the current timestamp at the start of query evaluation as a :class:`TimestampType`
@@ -2180,21 +2177,21 @@ func CurrentDate() column.Column {
 //
 // CurrentTimestamp is the Golang equivalent of current_timestamp: () -> pyspark.sql.connect.column.Column
 func CurrentTimestamp() column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("current_timestamp"))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("current_timestamp", ))
 }
 
 // Now - Returns the current timestamp at the start of query evaluation.
 //
 // Now is the Golang equivalent of now: () -> pyspark.sql.connect.column.Column
 func Now() column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("now"))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("now", ))
 }
 
 // CurrentTimezone - Returns the current session local timezone.
 //
 // CurrentTimezone is the Golang equivalent of current_timezone: () -> pyspark.sql.connect.column.Column
 func CurrentTimezone() column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("current_timezone"))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("current_timezone", ))
 }
 
 // Localtimestamp - Returns the current timestamp without time zone at the start of query evaluation
@@ -2203,40 +2200,40 @@ func CurrentTimezone() column.Column {
 //
 // Localtimestamp is the Golang equivalent of localtimestamp: () -> pyspark.sql.connect.column.Column
 func Localtimestamp() column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("localtimestamp"))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("localtimestamp", ))
 }
 
 // DateFormat - Converts a date/timestamp/string to a value of string in the format specified by the date
 // format given by the second argument.
-//
+// 
 // A pattern could be for instance `dd.MM.yyyy` and could return a string like '18.03.1993'. All
 // pattern letters of `datetime pattern`_. can be used.
 //
 // DateFormat is the Golang equivalent of date_format: (date: 'ColumnOrName', format: str) -> pyspark.sql.connect.column.Column
 func DateFormat(date column.Column, format string) column.Column {
-	lit_format := Lit(format)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("date_format", date, lit_format))
+    lit_format := StringLit(format)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("date_format", date, lit_format))
 }
 
 // Year - Extract the year of a given date/timestamp as integer.
 //
 // Year is the Golang equivalent of year: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Year(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("year", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("year", col))
 }
 
 // Quarter - Extract the quarter of a given date/timestamp as integer.
 //
 // Quarter is the Golang equivalent of quarter: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Quarter(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("quarter", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("quarter", col))
 }
 
 // Month - Extract the month of a given date/timestamp as integer.
 //
 // Month is the Golang equivalent of month: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Month(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("month", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("month", col))
 }
 
 // Dayofweek - Extract the day of the week of a given date/timestamp as integer.
@@ -2244,49 +2241,49 @@ func Month(col column.Column) column.Column {
 //
 // Dayofweek is the Golang equivalent of dayofweek: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Dayofweek(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("dayofweek", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("dayofweek", col))
 }
 
 // Dayofmonth - Extract the day of the month of a given date/timestamp as integer.
 //
 // Dayofmonth is the Golang equivalent of dayofmonth: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Dayofmonth(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("dayofmonth", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("dayofmonth", col))
 }
 
 // Day - Extract the day of the month of a given date/timestamp as integer.
 //
 // Day is the Golang equivalent of day: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Day(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("day", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("day", col))
 }
 
 // Dayofyear - Extract the day of the year of a given date/timestamp as integer.
 //
 // Dayofyear is the Golang equivalent of dayofyear: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Dayofyear(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("dayofyear", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("dayofyear", col))
 }
 
 // Hour - Extract the hours of a given timestamp as integer.
 //
 // Hour is the Golang equivalent of hour: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Hour(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("hour", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("hour", col))
 }
 
 // Minute - Extract the minutes of a given timestamp as integer.
 //
 // Minute is the Golang equivalent of minute: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Minute(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("minute", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("minute", col))
 }
 
 // Second - Extract the seconds of a given date as integer.
 //
 // Second is the Golang equivalent of second: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Second(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("second", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("second", col))
 }
 
 // Weekofyear - Extract the week number of a given date as integer.
@@ -2295,38 +2292,38 @@ func Second(col column.Column) column.Column {
 //
 // Weekofyear is the Golang equivalent of weekofyear: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Weekofyear(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("weekofyear", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("weekofyear", col))
 }
 
 // Weekday - Returns the day of the week for date/timestamp (0 = Monday, 1 = Tuesday, ..., 6 = Sunday).
 //
 // Weekday is the Golang equivalent of weekday: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Weekday(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("weekday", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("weekday", col))
 }
 
 // Extract - Extracts a part of the date/timestamp or interval source.
 //
 // Extract is the Golang equivalent of extract: (field: 'ColumnOrName', source: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Extract(field column.Column, source column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("extract", field, source))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("extract", field, source))
 }
 
 // DatePart is the Golang equivalent of date_part: (field: 'ColumnOrName', source: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func DatePart(field column.Column, source column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("date_part", field, source))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("date_part", field, source))
 }
 
 // Datepart is the Golang equivalent of datepart: (field: 'ColumnOrName', source: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Datepart(field column.Column, source column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("datepart", field, source))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("datepart", field, source))
 }
 
 // MakeDate - Returns a column with a date built from the year, month and day columns.
 //
 // MakeDate is the Golang equivalent of make_date: (year: 'ColumnOrName', month: 'ColumnOrName', day: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func MakeDate(year column.Column, month column.Column, day column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("make_date", year, month, day))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("make_date", year, month, day))
 }
 
 // DateAdd - Returns the date that is `days` days after `start`. If `days` is a negative value
@@ -2334,7 +2331,7 @@ func MakeDate(year column.Column, month column.Column, day column.Column) column
 //
 // DateAdd is the Golang equivalent of date_add: (start: 'ColumnOrName', days: Union[ForwardRef('ColumnOrName'), int]) -> pyspark.sql.connect.column.Column
 func DateAdd(start column.Column, days column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("date_add", start, days))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("date_add", start, days))
 }
 
 // Dateadd - Returns the date that is `days` days after `start`. If `days` is a negative value
@@ -2342,7 +2339,7 @@ func DateAdd(start column.Column, days column.Column) column.Column {
 //
 // Dateadd is the Golang equivalent of dateadd: (start: 'ColumnOrName', days: Union[ForwardRef('ColumnOrName'), int]) -> pyspark.sql.connect.column.Column
 func Dateadd(start column.Column, days column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("dateadd", start, days))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("dateadd", start, days))
 }
 
 // DateSub - Returns the date that is `days` days before `start`. If `days` is a negative value
@@ -2350,28 +2347,28 @@ func Dateadd(start column.Column, days column.Column) column.Column {
 //
 // DateSub is the Golang equivalent of date_sub: (start: 'ColumnOrName', days: Union[ForwardRef('ColumnOrName'), int]) -> pyspark.sql.connect.column.Column
 func DateSub(start column.Column, days column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("date_sub", start, days))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("date_sub", start, days))
 }
 
 // Datediff - Returns the number of days from `start` to `end`.
 //
 // Datediff is the Golang equivalent of datediff: (end: 'ColumnOrName', start: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Datediff(end column.Column, start column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("datediff", end, start))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("datediff", end, start))
 }
 
 // DateDiff - Returns the number of days from `start` to `end`.
 //
 // DateDiff is the Golang equivalent of date_diff: (end: 'ColumnOrName', start: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func DateDiff(end column.Column, start column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("date_diff", end, start))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("date_diff", end, start))
 }
 
 // DateFromUnixDate - Create date from the number of `days` since 1970-01-01.
 //
 // DateFromUnixDate is the Golang equivalent of date_from_unix_date: (days: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func DateFromUnixDate(days column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("date_from_unix_date", days))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("date_from_unix_date", days))
 }
 
 // AddMonths - Returns the date that is `months` months after `start`. If `months` is a negative value
@@ -2379,7 +2376,7 @@ func DateFromUnixDate(days column.Column) column.Column {
 //
 // AddMonths is the Golang equivalent of add_months: (start: 'ColumnOrName', months: Union[ForwardRef('ColumnOrName'), int]) -> pyspark.sql.connect.column.Column
 func AddMonths(start column.Column, months column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("add_months", start, months))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("add_months", start, months))
 }
 
 // TODO: months_between: (date1: 'ColumnOrName', date2: 'ColumnOrName', roundOff: bool = True) -> pyspark.sql.connect.column.Column
@@ -2387,26 +2384,26 @@ func AddMonths(start column.Column, months column.Column) column.Column {
 // ToDate - Converts a :class:`~pyspark.sql.Column` into :class:`pyspark.sql.types.DateType`
 // using the optionally specified format. Specify formats according to `datetime pattern`_.
 // By default, it follows casting rules to :class:`pyspark.sql.types.DateType` if the format
-// is omitted. Equivalent to “col.cast("date")“.
+// is omitted. Equivalent to ``col.cast("date")``.
 //
 // ToDate is the Golang equivalent of to_date: (col: 'ColumnOrName', format: Optional[str] = None) -> pyspark.sql.connect.column.Column
 func ToDate(col column.Column, format string) column.Column {
-	lit_format := Lit(format)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("to_date", col, lit_format))
+    lit_format := StringLit(format)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("to_date", col, lit_format))
 }
 
 // UnixDate - Returns the number of days since 1970-01-01.
 //
 // UnixDate is the Golang equivalent of unix_date: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func UnixDate(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("unix_date", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("unix_date", col))
 }
 
 // UnixMicros - Returns the number of microseconds since 1970-01-01 00:00:00 UTC.
 //
 // UnixMicros is the Golang equivalent of unix_micros: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func UnixMicros(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("unix_micros", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("unix_micros", col))
 }
 
 // UnixMillis - Returns the number of milliseconds since 1970-01-01 00:00:00 UTC.
@@ -2414,7 +2411,7 @@ func UnixMicros(col column.Column) column.Column {
 //
 // UnixMillis is the Golang equivalent of unix_millis: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func UnixMillis(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("unix_millis", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("unix_millis", col))
 }
 
 // UnixSeconds - Returns the number of seconds since 1970-01-01 00:00:00 UTC.
@@ -2422,18 +2419,18 @@ func UnixMillis(col column.Column) column.Column {
 //
 // UnixSeconds is the Golang equivalent of unix_seconds: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func UnixSeconds(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("unix_seconds", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("unix_seconds", col))
 }
 
 // ToTimestamp - Converts a :class:`~pyspark.sql.Column` into :class:`pyspark.sql.types.TimestampType`
 // using the optionally specified format. Specify formats according to `datetime pattern`_.
 // By default, it follows casting rules to :class:`pyspark.sql.types.TimestampType` if the format
-// is omitted. Equivalent to “col.cast("timestamp")“.
+// is omitted. Equivalent to ``col.cast("timestamp")``.
 //
 // ToTimestamp is the Golang equivalent of to_timestamp: (col: 'ColumnOrName', format: Optional[str] = None) -> pyspark.sql.connect.column.Column
 func ToTimestamp(col column.Column, format string) column.Column {
-	lit_format := Lit(format)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("to_timestamp", col, lit_format))
+    lit_format := StringLit(format)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("to_timestamp", col, lit_format))
 }
 
 // TryToTimestamp - Parses the `col` with the `format` to a timestamp. The function always
@@ -2442,21 +2439,21 @@ func ToTimestamp(col column.Column, format string) column.Column {
 //
 // TryToTimestamp is the Golang equivalent of try_to_timestamp: (col: 'ColumnOrName', format: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
 func TryToTimestamp(col column.Column, format column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_to_timestamp", col, format))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_to_timestamp", col, format))
 }
 
 // Xpath - Returns a string array of values within the nodes of xml that match the XPath expression.
 //
 // Xpath is the Golang equivalent of xpath: (xml: 'ColumnOrName', path: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Xpath(xml column.Column, path column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("xpath", xml, path))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("xpath", xml, path))
 }
 
 // XpathBoolean - Returns true if the XPath expression evaluates to true, or if a matching node is found.
 //
 // XpathBoolean is the Golang equivalent of xpath_boolean: (xml: 'ColumnOrName', path: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func XpathBoolean(xml column.Column, path column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("xpath_boolean", xml, path))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("xpath_boolean", xml, path))
 }
 
 // XpathDouble - Returns a double value, the value zero if no match is found,
@@ -2464,7 +2461,7 @@ func XpathBoolean(xml column.Column, path column.Column) column.Column {
 //
 // XpathDouble is the Golang equivalent of xpath_double: (xml: 'ColumnOrName', path: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func XpathDouble(xml column.Column, path column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("xpath_double", xml, path))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("xpath_double", xml, path))
 }
 
 // XpathNumber - Returns a double value, the value zero if no match is found,
@@ -2472,7 +2469,7 @@ func XpathDouble(xml column.Column, path column.Column) column.Column {
 //
 // XpathNumber is the Golang equivalent of xpath_number: (xml: 'ColumnOrName', path: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func XpathNumber(xml column.Column, path column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("xpath_number", xml, path))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("xpath_number", xml, path))
 }
 
 // XpathFloat - Returns a float value, the value zero if no match is found,
@@ -2480,7 +2477,7 @@ func XpathNumber(xml column.Column, path column.Column) column.Column {
 //
 // XpathFloat is the Golang equivalent of xpath_float: (xml: 'ColumnOrName', path: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func XpathFloat(xml column.Column, path column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("xpath_float", xml, path))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("xpath_float", xml, path))
 }
 
 // XpathInt - Returns an integer value, or the value zero if no match is found,
@@ -2488,7 +2485,7 @@ func XpathFloat(xml column.Column, path column.Column) column.Column {
 //
 // XpathInt is the Golang equivalent of xpath_int: (xml: 'ColumnOrName', path: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func XpathInt(xml column.Column, path column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("xpath_int", xml, path))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("xpath_int", xml, path))
 }
 
 // XpathLong - Returns a long integer value, or the value zero if no match is found,
@@ -2496,7 +2493,7 @@ func XpathInt(xml column.Column, path column.Column) column.Column {
 //
 // XpathLong is the Golang equivalent of xpath_long: (xml: 'ColumnOrName', path: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func XpathLong(xml column.Column, path column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("xpath_long", xml, path))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("xpath_long", xml, path))
 }
 
 // XpathShort - Returns a short integer value, or the value zero if no match is found,
@@ -2504,30 +2501,30 @@ func XpathLong(xml column.Column, path column.Column) column.Column {
 //
 // XpathShort is the Golang equivalent of xpath_short: (xml: 'ColumnOrName', path: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func XpathShort(xml column.Column, path column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("xpath_short", xml, path))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("xpath_short", xml, path))
 }
 
 // XpathString - Returns the text contents of the first xml node that matches the XPath expression.
 //
 // XpathString is the Golang equivalent of xpath_string: (xml: 'ColumnOrName', path: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func XpathString(xml column.Column, path column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("xpath_string", xml, path))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("xpath_string", xml, path))
 }
 
 // Trunc - Returns date truncated to the unit specified by the format.
 //
 // Trunc is the Golang equivalent of trunc: (date: 'ColumnOrName', format: str) -> pyspark.sql.connect.column.Column
 func Trunc(date column.Column, format string) column.Column {
-	lit_format := Lit(format)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("trunc", date, lit_format))
+    lit_format := StringLit(format)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("trunc", date, lit_format))
 }
 
 // DateTrunc - Returns timestamp truncated to the unit specified by the format.
 //
 // DateTrunc is the Golang equivalent of date_trunc: (format: str, timestamp: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func DateTrunc(format string, timestamp column.Column) column.Column {
-	lit_format := Lit(format)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("date_trunc", lit_format, timestamp))
+    lit_format := StringLit(format)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("date_trunc", lit_format, timestamp))
 }
 
 // NextDay - Returns the first date which is later than the value of the date column
@@ -2535,15 +2532,15 @@ func DateTrunc(format string, timestamp column.Column) column.Column {
 //
 // NextDay is the Golang equivalent of next_day: (date: 'ColumnOrName', dayOfWeek: str) -> pyspark.sql.connect.column.Column
 func NextDay(date column.Column, dayOfWeek string) column.Column {
-	lit_dayOfWeek := Lit(dayOfWeek)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("next_day", date, lit_dayOfWeek))
+    lit_dayOfWeek := StringLit(dayOfWeek)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("next_day", date, lit_dayOfWeek))
 }
 
 // LastDay - Returns the last day of the month which the given date belongs to.
 //
 // LastDay is the Golang equivalent of last_day: (date: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func LastDay(date column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("last_day", date))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("last_day", date))
 }
 
 // FromUnixtime - Converts the number of seconds from unix epoch (1970-01-01 00:00:00 UTC) to a string
@@ -2552,30 +2549,30 @@ func LastDay(date column.Column) column.Column {
 //
 // FromUnixtime is the Golang equivalent of from_unixtime: (timestamp: 'ColumnOrName', format: str = 'yyyy-MM-dd HH:mm:ss') -> pyspark.sql.connect.column.Column
 func FromUnixtime(timestamp column.Column, format string) column.Column {
-	lit_format := Lit(format)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("from_unixtime", timestamp, lit_format))
+    lit_format := StringLit(format)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("from_unixtime", timestamp, lit_format))
 }
 
 // UnixTimestamp - Convert time string with given pattern ('yyyy-MM-dd HH:mm:ss', by default)
 // to Unix time stamp (in seconds), using the default timezone and the default
 // locale, returns null if failed.
-//
+// 
 // if `timestamp` is None, then it returns current timestamp.
 //
 // UnixTimestamp is the Golang equivalent of unix_timestamp: (timestamp: Optional[ForwardRef('ColumnOrName')] = None, format: str = 'yyyy-MM-dd HH:mm:ss') -> pyspark.sql.connect.column.Column
 func UnixTimestamp(timestamp column.Column, format string) column.Column {
-	lit_format := Lit(format)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("unix_timestamp", timestamp, lit_format))
+    lit_format := StringLit(format)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("unix_timestamp", timestamp, lit_format))
 }
 
 // FromUtcTimestamp - This is a common function for databases supporting TIMESTAMP WITHOUT TIMEZONE. This function
 // takes a timestamp which is timezone-agnostic, and interprets it as a timestamp in UTC, and
 // renders that timestamp as a timestamp in the given time zone.
-//
+// 
 // However, timestamp in Spark represents number of microseconds from the Unix epoch, which is not
 // timezone-agnostic. So in Spark this function just shift the timestamp value from UTC timezone to
 // the given timezone.
-//
+// 
 // This function may return confusing result if the input is a string with timezone, e.g.
 // '2018-03-13T06:18:23+00:00'. The reason is that, Spark firstly cast the string to timestamp
 // according to the timezone in the string, and finally display the result by converting the
@@ -2583,17 +2580,17 @@ func UnixTimestamp(timestamp column.Column, format string) column.Column {
 //
 // FromUtcTimestamp is the Golang equivalent of from_utc_timestamp: (timestamp: 'ColumnOrName', tz: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func FromUtcTimestamp(timestamp column.Column, tz column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("from_utc_timestamp", timestamp, tz))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("from_utc_timestamp", timestamp, tz))
 }
 
 // ToUtcTimestamp - This is a common function for databases supporting TIMESTAMP WITHOUT TIMEZONE. This function
 // takes a timestamp which is timezone-agnostic, and interprets it as a timestamp in the given
 // timezone, and renders that timestamp as a timestamp in UTC.
-//
+// 
 // However, timestamp in Spark represents number of microseconds from the Unix epoch, which is not
 // timezone-agnostic. So in Spark this function just shift the timestamp value from the given
 // timezone to UTC timezone.
-//
+// 
 // This function may return confusing result if the input is a string with timezone, e.g.
 // '2018-03-13T06:18:23+00:00'. The reason is that, Spark firstly cast the string to timestamp
 // according to the timezone in the string, and finally display the result by converting the
@@ -2601,7 +2598,7 @@ func FromUtcTimestamp(timestamp column.Column, tz column.Column) column.Column {
 //
 // ToUtcTimestamp is the Golang equivalent of to_utc_timestamp: (timestamp: 'ColumnOrName', tz: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func ToUtcTimestamp(timestamp column.Column, tz column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("to_utc_timestamp", timestamp, tz))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("to_utc_timestamp", timestamp, tz))
 }
 
 // TimestampSeconds - Converts the number of seconds from the Unix epoch (1970-01-01T00:00:00Z)
@@ -2609,60 +2606,59 @@ func ToUtcTimestamp(timestamp column.Column, tz column.Column) column.Column {
 //
 // TimestampSeconds is the Golang equivalent of timestamp_seconds: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func TimestampSeconds(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("timestamp_seconds", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("timestamp_seconds", col))
 }
 
 // TimestampMillis - Creates timestamp from the number of milliseconds since UTC epoch.
 //
 // TimestampMillis is the Golang equivalent of timestamp_millis: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func TimestampMillis(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("timestamp_millis", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("timestamp_millis", col))
 }
 
 // TimestampMicros - Creates timestamp from the number of microseconds since UTC epoch.
 //
 // TimestampMicros is the Golang equivalent of timestamp_micros: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func TimestampMicros(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("timestamp_micros", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("timestamp_micros", col))
 }
 
 // Window - Bucketize rows into one or more time windows given a timestamp specifying column. Window
 // starts are inclusive but the window ends are exclusive, e.g. 12:05 will be in the window
 // [12:05,12:10) but not in [12:00,12:05). Windows can support microsecond precision. Windows in
 // the order of months are not supported.
-//
+// 
 // The time column must be of :class:`pyspark.sql.types.TimestampType`.
-//
+// 
 // Durations are provided as strings, e.g. '1 second', '1 day 12 hours', '2 minutes'. Valid
 // interval strings are 'week', 'day', 'hour', 'minute', 'second', 'millisecond', 'microsecond'.
-// If the “slideDuration“ is not provided, the windows will be tumbling windows.
-//
+// If the ``slideDuration`` is not provided, the windows will be tumbling windows.
+// 
 // The startTime is the offset with respect to 1970-01-01 00:00:00 UTC with which to start
 // window intervals. For example, in order to have hourly tumbling windows that start 15 minutes
 // past the hour, e.g. 12:15-13:15, 13:15-14:15... provide `startTime` as `15 minutes`.
-//
+// 
 // The output column will be a struct called 'window' by default with the nested columns 'start'
 // and 'end', where 'start' and 'end' will be of :class:`pyspark.sql.types.TimestampType`.
 //
 // Window is the Golang equivalent of window: (timeColumn: 'ColumnOrName', windowDuration: str, slideDuration: Optional[str] = None, startTime: Optional[str] = None) -> pyspark.sql.connect.column.Column
 func Window(timeColumn column.Column, windowDuration string, slideDuration string, startTime string) column.Column {
-	lit_windowDuration := Lit(windowDuration)
-	lit_slideDuration := Lit(slideDuration)
-	lit_startTime := Lit(startTime)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("window", timeColumn,
-		lit_windowDuration, lit_slideDuration, lit_startTime))
+    lit_windowDuration := StringLit(windowDuration)
+    lit_slideDuration := StringLit(slideDuration)
+    lit_startTime := StringLit(startTime)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("window", timeColumn, lit_windowDuration, lit_slideDuration, lit_startTime))
 }
 
 // WindowTime - Computes the event time from a window column. The column window values are produced
 // by window aggregating operators and are of type `STRUCT<start: TIMESTAMP, end: TIMESTAMP>`
 // where start is inclusive and end is exclusive. The event time of records produced by window
-// aggregating operators can be computed as “window_time(window)“ and are
-// “window.end - lit(1).alias("microsecond")“ (as microsecond is the minimal supported event
+// aggregating operators can be computed as ``window_time(window)`` and are
+// ``window.end - lit(1).alias("microsecond")`` (as microsecond is the minimal supported event
 // time precision). The window column must be one produced by a window aggregating operator.
 //
 // WindowTime is the Golang equivalent of window_time: (windowColumn: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func WindowTime(windowColumn column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("window_time", windowColumn))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("window_time", windowColumn))
 }
 
 // TODO: session_window: (timeColumn: 'ColumnOrName', gapDuration: Union[pyspark.sql.connect.column.Column, str]) -> pyspark.sql.connect.column.Column
@@ -2671,7 +2667,7 @@ func WindowTime(windowColumn column.Column) column.Column {
 //
 // ToUnixTimestamp is the Golang equivalent of to_unix_timestamp: (timestamp: 'ColumnOrName', format: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
 func ToUnixTimestamp(timestamp column.Column, format column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("to_unix_timestamp", timestamp, format))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("to_unix_timestamp", timestamp, format))
 }
 
 // ToTimestampLtz - Parses the `timestamp` with the `format` to a timestamp without time zone.
@@ -2679,7 +2675,7 @@ func ToUnixTimestamp(timestamp column.Column, format column.Column) column.Colum
 //
 // ToTimestampLtz is the Golang equivalent of to_timestamp_ltz: (timestamp: 'ColumnOrName', format: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
 func ToTimestampLtz(timestamp column.Column, format column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("to_timestamp_ltz", timestamp, format))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("to_timestamp_ltz", timestamp, format))
 }
 
 // ToTimestampNtz - Parses the `timestamp` with the `format` to a timestamp without time zone.
@@ -2687,7 +2683,7 @@ func ToTimestampLtz(timestamp column.Column, format column.Column) column.Column
 //
 // ToTimestampNtz is the Golang equivalent of to_timestamp_ntz: (timestamp: 'ColumnOrName', format: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
 func ToTimestampNtz(timestamp column.Column, format column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("to_timestamp_ntz", timestamp, format))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("to_timestamp_ntz", timestamp, format))
 }
 
 // TODO: bucket: (numBuckets: Union[pyspark.sql.connect.column.Column, int], col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
@@ -2697,7 +2693,7 @@ func ToTimestampNtz(timestamp column.Column, format column.Column) column.Column
 //
 // Years is the Golang equivalent of years: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Years(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("years", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("years", col))
 }
 
 // Months - Partition transform function: A transform for timestamps and dates
@@ -2705,7 +2701,7 @@ func Years(col column.Column) column.Column {
 //
 // Months is the Golang equivalent of months: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Months(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("months", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("months", col))
 }
 
 // Days - Partition transform function: A transform for timestamps and dates
@@ -2713,7 +2709,7 @@ func Months(col column.Column) column.Column {
 //
 // Days is the Golang equivalent of days: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Days(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("days", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("days", col))
 }
 
 // Hours - Partition transform function: A transform for timestamps
@@ -2721,7 +2717,7 @@ func Days(col column.Column) column.Column {
 //
 // Hours is the Golang equivalent of hours: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Hours(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("hours", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("hours", col))
 }
 
 // TODO: convert_timezone: (sourceTz: Optional[pyspark.sql.connect.column.Column], targetTz: pyspark.sql.connect.column.Column, sourceTs: 'ColumnOrName') -> pyspark.sql.connect.column.Column
@@ -2730,17 +2726,14 @@ func Hours(col column.Column) column.Column {
 //
 // MakeDtInterval is the Golang equivalent of make_dt_interval: (days: Optional[ForwardRef('ColumnOrName')] = None, hours: Optional[ForwardRef('ColumnOrName')] = None, mins: Optional[ForwardRef('ColumnOrName')] = None, secs: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
 func MakeDtInterval(days column.Column, hours column.Column, mins column.Column, secs column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("make_dt_interval", days, hours, mins, secs))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("make_dt_interval", days, hours, mins, secs))
 }
 
 // MakeInterval - Make interval from years, months, weeks, days, hours, mins and secs.
 //
 // MakeInterval is the Golang equivalent of make_interval: (years: Optional[ForwardRef('ColumnOrName')] = None, months: Optional[ForwardRef('ColumnOrName')] = None, weeks: Optional[ForwardRef('ColumnOrName')] = None, days: Optional[ForwardRef('ColumnOrName')] = None, hours: Optional[ForwardRef('ColumnOrName')] = None, mins: Optional[ForwardRef('ColumnOrName')] = None, secs: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
-func MakeInterval(years column.Column, months column.Column, weeks column.Column,
-	days column.Column, hours column.Column, mins column.Column, secs column.Column,
-) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("make_interval", years,
-		months, weeks, days, hours, mins, secs))
+func MakeInterval(years column.Column, months column.Column, weeks column.Column, days column.Column, hours column.Column, mins column.Column, secs column.Column) column.Column {
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("make_interval", years, months, weeks, days, hours, mins, secs))
 }
 
 // MakeTimestamp - Create timestamp from years, months, days, hours, mins, secs and timezone fields.
@@ -2749,11 +2742,8 @@ func MakeInterval(years column.Column, months column.Column, weeks column.Column
 // on invalid inputs. Otherwise, it will throw an error instead.
 //
 // MakeTimestamp is the Golang equivalent of make_timestamp: (years: 'ColumnOrName', months: 'ColumnOrName', days: 'ColumnOrName', hours: 'ColumnOrName', mins: 'ColumnOrName', secs: 'ColumnOrName', timezone: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
-func MakeTimestamp(years column.Column, months column.Column, days column.Column,
-	hours column.Column, mins column.Column, secs column.Column, timezone column.Column,
-) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("make_timestamp", years,
-		months, days, hours, mins, secs, timezone))
+func MakeTimestamp(years column.Column, months column.Column, days column.Column, hours column.Column, mins column.Column, secs column.Column, timezone column.Column) column.Column {
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("make_timestamp", years, months, days, hours, mins, secs, timezone))
 }
 
 // MakeTimestampLtz - Create the current timestamp with local time zone from years, months, days, hours, mins,
@@ -2761,11 +2751,8 @@ func MakeTimestamp(years column.Column, months column.Column, days column.Column
 // the function returns NULL on invalid inputs. Otherwise, it will throw an error instead.
 //
 // MakeTimestampLtz is the Golang equivalent of make_timestamp_ltz: (years: 'ColumnOrName', months: 'ColumnOrName', days: 'ColumnOrName', hours: 'ColumnOrName', mins: 'ColumnOrName', secs: 'ColumnOrName', timezone: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
-func MakeTimestampLtz(years column.Column, months column.Column, days column.Column,
-	hours column.Column, mins column.Column, secs column.Column, timezone column.Column,
-) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("make_timestamp_ltz",
-		years, months, days, hours, mins, secs, timezone))
+func MakeTimestampLtz(years column.Column, months column.Column, days column.Column, hours column.Column, mins column.Column, secs column.Column, timezone column.Column) column.Column {
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("make_timestamp_ltz", years, months, days, hours, mins, secs, timezone))
 }
 
 // MakeTimestampNtz - Create local date-time from years, months, days, hours, mins, secs fields.
@@ -2773,53 +2760,50 @@ func MakeTimestampLtz(years column.Column, months column.Column, days column.Col
 // on invalid inputs. Otherwise, it will throw an error instead.
 //
 // MakeTimestampNtz is the Golang equivalent of make_timestamp_ntz: (years: 'ColumnOrName', months: 'ColumnOrName', days: 'ColumnOrName', hours: 'ColumnOrName', mins: 'ColumnOrName', secs: 'ColumnOrName') -> pyspark.sql.connect.column.Column
-func MakeTimestampNtz(years column.Column, months column.Column, days column.Column,
-	hours column.Column, mins column.Column, secs column.Column,
-) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("make_timestamp_ntz",
-		years, months, days, hours, mins, secs))
+func MakeTimestampNtz(years column.Column, months column.Column, days column.Column, hours column.Column, mins column.Column, secs column.Column) column.Column {
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("make_timestamp_ntz", years, months, days, hours, mins, secs))
 }
 
 // MakeYmInterval - Make year-month interval from years, months.
 //
 // MakeYmInterval is the Golang equivalent of make_ym_interval: (years: Optional[ForwardRef('ColumnOrName')] = None, months: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
 func MakeYmInterval(years column.Column, months column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("make_ym_interval", years, months))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("make_ym_interval", years, months))
 }
 
 // CurrentCatalog - Returns the current catalog.
 //
 // CurrentCatalog is the Golang equivalent of current_catalog: () -> pyspark.sql.connect.column.Column
 func CurrentCatalog() column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("current_catalog"))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("current_catalog", ))
 }
 
 // CurrentDatabase - Returns the current database.
 //
 // CurrentDatabase is the Golang equivalent of current_database: () -> pyspark.sql.connect.column.Column
 func CurrentDatabase() column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("current_database"))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("current_database", ))
 }
 
 // CurrentSchema - Returns the current database.
 //
 // CurrentSchema is the Golang equivalent of current_schema: () -> pyspark.sql.connect.column.Column
 func CurrentSchema() column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("current_schema"))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("current_schema", ))
 }
 
 // CurrentUser - Returns the current database.
 //
 // CurrentUser is the Golang equivalent of current_user: () -> pyspark.sql.connect.column.Column
 func CurrentUser() column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("current_user"))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("current_user", ))
 }
 
 // User - Returns the current database.
 //
 // User is the Golang equivalent of user: () -> pyspark.sql.connect.column.Column
 func User() column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("user"))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("user", ))
 }
 
 // TODO: assert_true: (col: 'ColumnOrName', errMsg: Union[pyspark.sql.connect.column.Column, str, NoneType] = None) -> pyspark.sql.connect.column.Column
@@ -2831,16 +2815,16 @@ func User() column.Column {
 //
 // Crc32 is the Golang equivalent of crc32: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Crc32(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("crc32", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("crc32", col))
 }
 
 // Hash - Calculates the hash code of given columns, and returns the result as an int column.
 //
 // Hash is the Golang equivalent of hash: (*cols: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Hash(cols ...column.Column) column.Column {
-	vals := make([]column.Column, 0)
-	vals = append(vals, cols...)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("hash", vals...))
+    vals := make([]column.Column, 0)
+    vals = append(vals, cols...)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("hash", vals...))
 }
 
 // Xxhash64 - Calculates the hash code of given columns using the 64-bit variant of the xxHash algorithm,
@@ -2848,23 +2832,23 @@ func Hash(cols ...column.Column) column.Column {
 //
 // Xxhash64 is the Golang equivalent of xxhash64: (*cols: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Xxhash64(cols ...column.Column) column.Column {
-	vals := make([]column.Column, 0)
-	vals = append(vals, cols...)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("xxhash64", vals...))
+    vals := make([]column.Column, 0)
+    vals = append(vals, cols...)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("xxhash64", vals...))
 }
 
 // Md5 - Calculates the MD5 digest and returns the value as a 32 character hex string.
 //
 // Md5 is the Golang equivalent of md5: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Md5(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("md5", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("md5", col))
 }
 
 // Sha1 - Returns the hex string result of SHA-1.
 //
 // Sha1 is the Golang equivalent of sha1: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Sha1(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sha1", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sha1", col))
 }
 
 // Sha2 - Returns the hex string result of SHA-2 family of hash functions (SHA-224, SHA-256, SHA-384,
@@ -2873,8 +2857,8 @@ func Sha1(col column.Column) column.Column {
 //
 // Sha2 is the Golang equivalent of sha2: (col: 'ColumnOrName', numBits: int) -> pyspark.sql.connect.column.Column
 func Sha2(col column.Column, numBits int64) column.Column {
-	lit_numBits := Lit(numBits)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sha2", col, lit_numBits))
+    lit_numBits := Int64Lit(numBits)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sha2", col, lit_numBits))
 }
 
 // TODO: hll_sketch_agg: (col: 'ColumnOrName', lgConfigK: Union[int, pyspark.sql.connect.column.Column, NoneType] = None) -> pyspark.sql.connect.column.Column
@@ -2886,7 +2870,7 @@ func Sha2(col column.Column, numBits int64) column.Column {
 //
 // HllSketchEstimate is the Golang equivalent of hll_sketch_estimate: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func HllSketchEstimate(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("hll_sketch_estimate", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("hll_sketch_estimate", col))
 }
 
 // TODO: hll_union: (col1: 'ColumnOrName', col2: 'ColumnOrName', allowDifferentLgConfigK: Optional[bool] = None) -> pyspark.sql.connect.column.Column
@@ -2895,14 +2879,14 @@ func HllSketchEstimate(col column.Column) column.Column {
 //
 // Ifnull is the Golang equivalent of ifnull: (col1: 'ColumnOrName', col2: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Ifnull(col1 column.Column, col2 column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("ifnull", col1, col2))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("ifnull", col1, col2))
 }
 
 // Isnotnull - Returns true if `col` is not null, or false otherwise.
 //
 // Isnotnull is the Golang equivalent of isnotnull: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Isnotnull(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("isnotnull", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("isnotnull", col))
 }
 
 // EqualNull - Returns same result as the EQUAL(=) operator for non-null operands,
@@ -2910,28 +2894,28 @@ func Isnotnull(col column.Column) column.Column {
 //
 // EqualNull is the Golang equivalent of equal_null: (col1: 'ColumnOrName', col2: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func EqualNull(col1 column.Column, col2 column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("equal_null", col1, col2))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("equal_null", col1, col2))
 }
 
 // Nullif - Returns null if `col1` equals to `col2`, or `col1` otherwise.
 //
 // Nullif is the Golang equivalent of nullif: (col1: 'ColumnOrName', col2: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Nullif(col1 column.Column, col2 column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("nullif", col1, col2))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("nullif", col1, col2))
 }
 
 // Nvl - Returns `col2` if `col1` is null, or `col1` otherwise.
 //
 // Nvl is the Golang equivalent of nvl: (col1: 'ColumnOrName', col2: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Nvl(col1 column.Column, col2 column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("nvl", col1, col2))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("nvl", col1, col2))
 }
 
 // Nvl2 - Returns `col2` if `col1` is not null, or `col3` otherwise.
 //
 // Nvl2 is the Golang equivalent of nvl2: (col1: 'ColumnOrName', col2: 'ColumnOrName', col3: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Nvl2(col1 column.Column, col2 column.Column, col3 column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("nvl2", col1, col2, col3))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("nvl2", col1, col2, col3))
 }
 
 // AesEncrypt - Returns an encrypted value of `input` using AES in given `mode` with the specified `padding`.
@@ -2945,7 +2929,7 @@ func Nvl2(col1 column.Column, col2 column.Column, col3 column.Column) column.Col
 //
 // AesEncrypt is the Golang equivalent of aes_encrypt: (input: 'ColumnOrName', key: 'ColumnOrName', mode: Optional[ForwardRef('ColumnOrName')] = None, padding: Optional[ForwardRef('ColumnOrName')] = None, iv: Optional[ForwardRef('ColumnOrName')] = None, aad: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
 func AesEncrypt(input column.Column, key column.Column, mode column.Column, padding column.Column, iv column.Column, aad column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("aes_encrypt", input, key, mode, padding, iv, aad))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("aes_encrypt", input, key, mode, padding, iv, aad))
 }
 
 // AesDecrypt - Returns a decrypted value of `input` using AES in `mode` with `padding`. Key lengths of 16,
@@ -2956,7 +2940,7 @@ func AesEncrypt(input column.Column, key column.Column, mode column.Column, padd
 //
 // AesDecrypt is the Golang equivalent of aes_decrypt: (input: 'ColumnOrName', key: 'ColumnOrName', mode: Optional[ForwardRef('ColumnOrName')] = None, padding: Optional[ForwardRef('ColumnOrName')] = None, aad: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
 func AesDecrypt(input column.Column, key column.Column, mode column.Column, padding column.Column, aad column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("aes_decrypt", input, key, mode, padding, aad))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("aes_decrypt", input, key, mode, padding, aad))
 }
 
 // TryAesDecrypt - This is a special version of `aes_decrypt` that performs the same operation,
@@ -2969,46 +2953,46 @@ func AesDecrypt(input column.Column, key column.Column, mode column.Column, padd
 //
 // TryAesDecrypt is the Golang equivalent of try_aes_decrypt: (input: 'ColumnOrName', key: 'ColumnOrName', mode: Optional[ForwardRef('ColumnOrName')] = None, padding: Optional[ForwardRef('ColumnOrName')] = None, aad: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
 func TryAesDecrypt(input column.Column, key column.Column, mode column.Column, padding column.Column, aad column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_aes_decrypt", input, key, mode, padding, aad))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_aes_decrypt", input, key, mode, padding, aad))
 }
 
 // Sha - Returns a sha1 hash value as a hex string of the `col`.
 //
 // Sha is the Golang equivalent of sha: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Sha(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sha", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sha", col))
 }
 
 // InputFileBlockLength - Returns the length of the block being read, or -1 if not available.
 //
 // InputFileBlockLength is the Golang equivalent of input_file_block_length: () -> pyspark.sql.connect.column.Column
 func InputFileBlockLength() column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("input_file_block_length"))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("input_file_block_length", ))
 }
 
 // InputFileBlockStart - Returns the start offset of the block being read, or -1 if not available.
 //
 // InputFileBlockStart is the Golang equivalent of input_file_block_start: () -> pyspark.sql.connect.column.Column
 func InputFileBlockStart() column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("input_file_block_start"))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("input_file_block_start", ))
 }
 
 // Reflect - Calls a method with reflection.
 //
 // Reflect is the Golang equivalent of reflect: (*cols: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Reflect(cols ...column.Column) column.Column {
-	vals := make([]column.Column, 0)
-	vals = append(vals, cols...)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("reflect", vals...))
+    vals := make([]column.Column, 0)
+    vals = append(vals, cols...)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("reflect", vals...))
 }
 
 // JavaMethod - Calls a method with reflection.
 //
 // JavaMethod is the Golang equivalent of java_method: (*cols: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func JavaMethod(cols ...column.Column) column.Column {
-	vals := make([]column.Column, 0)
-	vals = append(vals, cols...)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("java_method", vals...))
+    vals := make([]column.Column, 0)
+    vals = append(vals, cols...)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("java_method", vals...))
 }
 
 // Version - Returns the Spark version. The string contains 2 fields, the first being a release version
@@ -3016,14 +3000,14 @@ func JavaMethod(cols ...column.Column) column.Column {
 //
 // Version is the Golang equivalent of version: () -> pyspark.sql.connect.column.Column
 func Version() column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("version"))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("version", ))
 }
 
 // Typeof - Return DDL-formatted type string for the data type of the input.
 //
 // Typeof is the Golang equivalent of typeof: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Typeof(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("typeof", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("typeof", col))
 }
 
 // Stack - Separates `col1`, ..., `colk` into `n` rows. Uses column names col0, col1, etc. by default
@@ -3031,23 +3015,23 @@ func Typeof(col column.Column) column.Column {
 //
 // Stack is the Golang equivalent of stack: (*cols: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Stack(cols ...column.Column) column.Column {
-	vals := make([]column.Column, 0)
-	vals = append(vals, cols...)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("stack", vals...))
+    vals := make([]column.Column, 0)
+    vals = append(vals, cols...)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("stack", vals...))
 }
 
 // BitmapBitPosition - Returns the bit position for the given input column.
 //
 // BitmapBitPosition is the Golang equivalent of bitmap_bit_position: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func BitmapBitPosition(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bitmap_bit_position", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bitmap_bit_position", col))
 }
 
 // BitmapBucketNumber - Returns the bucket number for the given input column.
 //
 // BitmapBucketNumber is the Golang equivalent of bitmap_bucket_number: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func BitmapBucketNumber(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bitmap_bucket_number", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bitmap_bucket_number", col))
 }
 
 // BitmapConstructAgg - Returns a bitmap with the positions of the bits set from all the values from the input column.
@@ -3055,14 +3039,14 @@ func BitmapBucketNumber(col column.Column) column.Column {
 //
 // BitmapConstructAgg is the Golang equivalent of bitmap_construct_agg: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func BitmapConstructAgg(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bitmap_construct_agg", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bitmap_construct_agg", col))
 }
 
 // BitmapCount - Returns the number of set bits in the input bitmap.
 //
 // BitmapCount is the Golang equivalent of bitmap_count: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func BitmapCount(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bitmap_count", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bitmap_count", col))
 }
 
 // BitmapOrAgg - Returns a bitmap that is the bitwise OR of all of the bitmaps from the input column.
@@ -3070,7 +3054,7 @@ func BitmapCount(col column.Column) column.Column {
 //
 // BitmapOrAgg is the Golang equivalent of bitmap_or_agg: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func BitmapOrAgg(col column.Column) column.Column {
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bitmap_or_agg", col))
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bitmap_or_agg", col))
 }
 
 // Ignore UDF: call_udf: (udfName: str, *cols: 'ColumnOrName') -> pyspark.sql.connect.column.Column
@@ -3085,9 +3069,10 @@ func BitmapOrAgg(col column.Column) column.Column {
 //
 // CallFunction is the Golang equivalent of call_function: (funcName: str, *cols: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func CallFunction(funcName string, cols ...column.Column) column.Column {
-	lit_funcName := Lit(funcName)
-	vals := make([]column.Column, 0)
-	vals = append(vals, lit_funcName)
-	vals = append(vals, cols...)
-	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("call_function", vals...))
+    lit_funcName := StringLit(funcName)
+    vals := make([]column.Column, 0)
+    vals = append(vals, lit_funcName)
+    vals = append(vals, cols...)
+    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("call_function", vals...))
 }
+

--- a/spark/sql/functions/generated.go
+++ b/spark/sql/functions/generated.go
@@ -1,4 +1,3 @@
-
 // Licensed to the Apache Software Foundation (ASF) under one or more
 // contributor license agreements.  See the NOTICE file distributed with
 // this work for additional information regarding copyright ownership.
@@ -22,14 +21,14 @@ import "github.com/apache/spark-connect-go/v35/spark/sql/column"
 //
 // BitwiseNOT is the Golang equivalent of bitwiseNOT: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func BitwiseNOT(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bitwiseNOT", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bitwiseNOT", col))
 }
 
 // BitwiseNot - Computes bitwise not.
 //
 // BitwiseNot is the Golang equivalent of bitwise_not: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func BitwiseNot(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bitwise_not", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bitwise_not", col))
 }
 
 // BitCount - Returns the number of bits that are set in the argument expr as an unsigned 64-bit integer,
@@ -37,7 +36,7 @@ func BitwiseNot(col column.Column) column.Column {
 //
 // BitCount is the Golang equivalent of bit_count: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func BitCount(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bit_count", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bit_count", col))
 }
 
 // BitGet - Returns the value of the bit (0 or 1) at the specified position.
@@ -46,7 +45,7 @@ func BitCount(col column.Column) column.Column {
 //
 // BitGet is the Golang equivalent of bit_get: (col: 'ColumnOrName', pos: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func BitGet(col column.Column, pos column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bit_get", col, pos))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bit_get", col, pos))
 }
 
 // Getbit - Returns the value of the bit (0 or 1) at the specified position.
@@ -55,7 +54,7 @@ func BitGet(col column.Column, pos column.Column) column.Column {
 //
 // Getbit is the Golang equivalent of getbit: (col: 'ColumnOrName', pos: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Getbit(col column.Column, pos column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("getbit", col, pos))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("getbit", col, pos))
 }
 
 // TODO: broadcast: (df: 'DataFrame') -> 'DataFrame'
@@ -64,9 +63,9 @@ func Getbit(col column.Column, pos column.Column) column.Column {
 //
 // Coalesce is the Golang equivalent of coalesce: (*cols: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Coalesce(cols ...column.Column) column.Column {
-    vals := make([]column.Column, 0)
-    vals = append(vals, cols...)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("coalesce", vals...))
+	vals := make([]column.Column, 0)
+	vals = append(vals, cols...)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("coalesce", vals...))
 }
 
 // Greatest - Returns the greatest value of the list of column names, skipping null values.
@@ -74,16 +73,16 @@ func Coalesce(cols ...column.Column) column.Column {
 //
 // Greatest is the Golang equivalent of greatest: (*cols: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Greatest(cols ...column.Column) column.Column {
-    vals := make([]column.Column, 0)
-    vals = append(vals, cols...)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("greatest", vals...))
+	vals := make([]column.Column, 0)
+	vals = append(vals, cols...)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("greatest", vals...))
 }
 
 // InputFileName - Creates a string column for the file name of the current Spark task.
 //
 // InputFileName is the Golang equivalent of input_file_name: () -> pyspark.sql.connect.column.Column
 func InputFileName() column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("input_file_name", ))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("input_file_name"))
 }
 
 // Least - Returns the least value of the list of column names, skipping null values.
@@ -91,27 +90,27 @@ func InputFileName() column.Column {
 //
 // Least is the Golang equivalent of least: (*cols: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Least(cols ...column.Column) column.Column {
-    vals := make([]column.Column, 0)
-    vals = append(vals, cols...)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("least", vals...))
+	vals := make([]column.Column, 0)
+	vals = append(vals, cols...)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("least", vals...))
 }
 
 // Isnan - An expression that returns true if the column is NaN.
 //
 // Isnan is the Golang equivalent of isnan: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Isnan(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("isnan", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("isnan", col))
 }
 
 // Isnull - An expression that returns true if the column is null.
 //
 // Isnull is the Golang equivalent of isnull: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Isnull(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("isnull", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("isnull", col))
 }
 
 // MonotonicallyIncreasingId - A column that generates monotonically increasing 64-bit integers.
-// 
+//
 // The generated ID is guaranteed to be monotonically increasing and unique, but not consecutive.
 // The current implementation puts the partition ID in the upper 31 bits, and the record number
 // within each partition in the lower 33 bits. The assumption is that the data frame has
@@ -119,16 +118,16 @@ func Isnull(col column.Column) column.Column {
 //
 // MonotonicallyIncreasingId is the Golang equivalent of monotonically_increasing_id: () -> pyspark.sql.connect.column.Column
 func MonotonicallyIncreasingId() column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("monotonically_increasing_id", ))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("monotonically_increasing_id"))
 }
 
 // Nanvl - Returns col1 if it is not NaN, or col2 if col1 is NaN.
-// 
+//
 // Both inputs should be floating point columns (:class:`DoubleType` or :class:`FloatType`).
 //
 // Nanvl is the Golang equivalent of nanvl: (col1: 'ColumnOrName', col2: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Nanvl(col1 column.Column, col2 column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("nanvl", col1, col2))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("nanvl", col1, col2))
 }
 
 // Rand - Generates a random column with independent and identically distributed (i.i.d.) samples
@@ -136,8 +135,8 @@ func Nanvl(col1 column.Column, col2 column.Column) column.Column {
 //
 // Rand is the Golang equivalent of rand: (seed: Optional[int] = None) -> pyspark.sql.connect.column.Column
 func Rand(seed int64) column.Column {
-    lit_seed := Int64Lit(seed)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("rand", lit_seed))
+	lit_seed := Int64Lit(seed)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("rand", lit_seed))
 }
 
 // Randn - Generates a column with independent and identically distributed (i.i.d.) samples from
@@ -145,15 +144,15 @@ func Rand(seed int64) column.Column {
 //
 // Randn is the Golang equivalent of randn: (seed: Optional[int] = None) -> pyspark.sql.connect.column.Column
 func Randn(seed int64) column.Column {
-    lit_seed := Int64Lit(seed)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("randn", lit_seed))
+	lit_seed := Int64Lit(seed)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("randn", lit_seed))
 }
 
 // SparkPartitionId - A column for partition ID.
 //
 // SparkPartitionId is the Golang equivalent of spark_partition_id: () -> pyspark.sql.connect.column.Column
 func SparkPartitionId() column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("spark_partition_id", ))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("spark_partition_id"))
 }
 
 // TODO: when: (condition: pyspark.sql.connect.column.Column, value: Any) -> pyspark.sql.connect.column.Column
@@ -162,7 +161,7 @@ func SparkPartitionId() column.Column {
 //
 // Asc is the Golang equivalent of asc: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Asc(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("asc", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("asc", col))
 }
 
 // AscNullsFirst - Returns a sort expression based on the ascending order of the given
@@ -170,7 +169,7 @@ func Asc(col column.Column) column.Column {
 //
 // AscNullsFirst is the Golang equivalent of asc_nulls_first: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func AscNullsFirst(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("asc_nulls_first", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("asc_nulls_first", col))
 }
 
 // AscNullsLast - Returns a sort expression based on the ascending order of the given
@@ -178,14 +177,14 @@ func AscNullsFirst(col column.Column) column.Column {
 //
 // AscNullsLast is the Golang equivalent of asc_nulls_last: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func AscNullsLast(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("asc_nulls_last", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("asc_nulls_last", col))
 }
 
 // Desc - Returns a sort expression based on the descending order of the given column name.
 //
 // Desc is the Golang equivalent of desc: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Desc(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("desc", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("desc", col))
 }
 
 // DescNullsFirst - Returns a sort expression based on the descending order of the given
@@ -193,7 +192,7 @@ func Desc(col column.Column) column.Column {
 //
 // DescNullsFirst is the Golang equivalent of desc_nulls_first: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func DescNullsFirst(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("desc_nulls_first", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("desc_nulls_first", col))
 }
 
 // DescNullsLast - Returns a sort expression based on the descending order of the given
@@ -201,70 +200,70 @@ func DescNullsFirst(col column.Column) column.Column {
 //
 // DescNullsLast is the Golang equivalent of desc_nulls_last: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func DescNullsLast(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("desc_nulls_last", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("desc_nulls_last", col))
 }
 
 // Abs - Computes the absolute value.
 //
 // Abs is the Golang equivalent of abs: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Abs(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("abs", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("abs", col))
 }
 
 // Acos - Computes inverse cosine of the input column.
 //
 // Acos is the Golang equivalent of acos: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Acos(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("acos", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("acos", col))
 }
 
 // Acosh - Computes inverse hyperbolic cosine of the input column.
 //
 // Acosh is the Golang equivalent of acosh: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Acosh(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("acosh", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("acosh", col))
 }
 
 // Asin - Computes inverse sine of the input column.
 //
 // Asin is the Golang equivalent of asin: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Asin(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("asin", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("asin", col))
 }
 
 // Asinh - Computes inverse hyperbolic sine of the input column.
 //
 // Asinh is the Golang equivalent of asinh: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Asinh(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("asinh", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("asinh", col))
 }
 
 // Atan - Compute inverse tangent of the input column.
 //
 // Atan is the Golang equivalent of atan: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Atan(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("atan", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("atan", col))
 }
 
-// Atan2 - 
+// Atan2 -
 //
 // Atan2 is the Golang equivalent of atan2: (col1: Union[ForwardRef('ColumnOrName'), float], col2: Union[ForwardRef('ColumnOrName'), float]) -> pyspark.sql.connect.column.Column
 func Atan2(col1 column.Column, col2 column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("atan2", col1, col2))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("atan2", col1, col2))
 }
 
 // Atanh - Computes inverse hyperbolic tangent of the input column.
 //
 // Atanh is the Golang equivalent of atanh: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Atanh(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("atanh", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("atanh", col))
 }
 
 // Bin - Returns the string representation of the binary value of the given column.
 //
 // Bin is the Golang equivalent of bin: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Bin(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bin", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bin", col))
 }
 
 // Bround - Round the given value to `scale` decimal places using HALF_EVEN rounding mode if `scale` >= 0
@@ -272,66 +271,66 @@ func Bin(col column.Column) column.Column {
 //
 // Bround is the Golang equivalent of bround: (col: 'ColumnOrName', scale: int = 0) -> pyspark.sql.connect.column.Column
 func Bround(col column.Column, scale int64) column.Column {
-    lit_scale := Int64Lit(scale)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bround", col, lit_scale))
+	lit_scale := Int64Lit(scale)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bround", col, lit_scale))
 }
 
 // Cbrt - Computes the cube-root of the given value.
 //
 // Cbrt is the Golang equivalent of cbrt: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Cbrt(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("cbrt", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("cbrt", col))
 }
 
 // Ceil - Computes the ceiling of the given value.
 //
 // Ceil is the Golang equivalent of ceil: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Ceil(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("ceil", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("ceil", col))
 }
 
 // Ceiling - Computes the ceiling of the given value.
 //
 // Ceiling is the Golang equivalent of ceiling: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Ceiling(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("ceiling", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("ceiling", col))
 }
 
 // Conv - Convert a number in a string column from one base to another.
 //
 // Conv is the Golang equivalent of conv: (col: 'ColumnOrName', fromBase: int, toBase: int) -> pyspark.sql.connect.column.Column
 func Conv(col column.Column, fromBase int64, toBase int64) column.Column {
-    lit_fromBase := Int64Lit(fromBase)
-    lit_toBase := Int64Lit(toBase)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("conv", col, lit_fromBase, lit_toBase))
+	lit_fromBase := Int64Lit(fromBase)
+	lit_toBase := Int64Lit(toBase)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("conv", col, lit_fromBase, lit_toBase))
 }
 
 // Cos - Computes cosine of the input column.
 //
 // Cos is the Golang equivalent of cos: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Cos(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("cos", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("cos", col))
 }
 
 // Cosh - Computes hyperbolic cosine of the input column.
 //
 // Cosh is the Golang equivalent of cosh: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Cosh(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("cosh", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("cosh", col))
 }
 
 // Cot - Computes cotangent of the input column.
 //
 // Cot is the Golang equivalent of cot: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Cot(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("cot", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("cot", col))
 }
 
 // Csc - Computes cosecant of the input column.
 //
 // Csc is the Golang equivalent of csc: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Csc(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("csc", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("csc", col))
 }
 
 // Degrees - Converts an angle measured in radians to an approximately equivalent angle
@@ -339,42 +338,42 @@ func Csc(col column.Column) column.Column {
 //
 // Degrees is the Golang equivalent of degrees: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Degrees(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("degrees", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("degrees", col))
 }
 
 // E - Returns Euler's number.
 //
 // E is the Golang equivalent of e: () -> pyspark.sql.connect.column.Column
 func E() column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("e", ))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("e"))
 }
 
 // Exp - Computes the exponential of the given value.
 //
 // Exp is the Golang equivalent of exp: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Exp(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("exp", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("exp", col))
 }
 
 // Expm1 - Computes the exponential of the given value minus one.
 //
 // Expm1 is the Golang equivalent of expm1: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Expm1(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("expm1", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("expm1", col))
 }
 
 // Factorial - Computes the factorial of the given value.
 //
 // Factorial is the Golang equivalent of factorial: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Factorial(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("factorial", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("factorial", col))
 }
 
 // Floor - Computes the floor of the given value.
 //
 // Floor is the Golang equivalent of floor: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Floor(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("floor", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("floor", col))
 }
 
 // Hex - Computes hex value of the given column, which could be :class:`pyspark.sql.types.StringType`,
@@ -383,86 +382,86 @@ func Floor(col column.Column) column.Column {
 //
 // Hex is the Golang equivalent of hex: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Hex(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("hex", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("hex", col))
 }
 
-// Hypot - Computes ``sqrt(a^2 + b^2)`` without intermediate overflow or underflow.
+// Hypot - Computes “sqrt(a^2 + b^2)“ without intermediate overflow or underflow.
 //
 // Hypot is the Golang equivalent of hypot: (col1: Union[ForwardRef('ColumnOrName'), float], col2: Union[ForwardRef('ColumnOrName'), float]) -> pyspark.sql.connect.column.Column
 func Hypot(col1 column.Column, col2 column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("hypot", col1, col2))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("hypot", col1, col2))
 }
 
 // Log - Returns the first argument-based logarithm of the second argument.
-// 
+//
 // If there is only one argument, then this takes the natural logarithm of the argument.
 //
 // Log is the Golang equivalent of log: (arg1: Union[ForwardRef('ColumnOrName'), float], arg2: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
 func Log(arg1 column.Column, arg2 column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("log", arg1, arg2))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("log", arg1, arg2))
 }
 
 // Log10 - Computes the logarithm of the given value in Base 10.
 //
 // Log10 is the Golang equivalent of log10: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Log10(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("log10", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("log10", col))
 }
 
 // Log1p - Computes the natural logarithm of the "given value plus one".
 //
 // Log1p is the Golang equivalent of log1p: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Log1p(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("log1p", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("log1p", col))
 }
 
 // Ln - Returns the natural logarithm of the argument.
 //
 // Ln is the Golang equivalent of ln: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Ln(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("ln", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("ln", col))
 }
 
 // Log2 - Returns the base-2 logarithm of the argument.
 //
 // Log2 is the Golang equivalent of log2: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Log2(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("log2", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("log2", col))
 }
 
 // Negative - Returns the negative value.
 //
 // Negative is the Golang equivalent of negative: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Negative(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("negative", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("negative", col))
 }
 
 // Negate - Returns the negative value.
 //
 // Negate is the Golang equivalent of negate: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Negate(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("negate", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("negate", col))
 }
 
 // Pi - Returns Pi.
 //
 // Pi is the Golang equivalent of pi: () -> pyspark.sql.connect.column.Column
 func Pi() column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("pi", ))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("pi"))
 }
 
 // Positive - Returns the value.
 //
 // Positive is the Golang equivalent of positive: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Positive(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("positive", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("positive", col))
 }
 
 // Pmod - Returns the positive value of dividend mod divisor.
 //
 // Pmod is the Golang equivalent of pmod: (dividend: Union[ForwardRef('ColumnOrName'), float], divisor: Union[ForwardRef('ColumnOrName'), float]) -> pyspark.sql.connect.column.Column
 func Pmod(dividend column.Column, divisor column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("pmod", dividend, divisor))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("pmod", dividend, divisor))
 }
 
 // WidthBucket - Returns the bucket number into which the value of this expression would fall
@@ -471,14 +470,14 @@ func Pmod(dividend column.Column, divisor column.Column) column.Column {
 //
 // WidthBucket is the Golang equivalent of width_bucket: (v: 'ColumnOrName', min: 'ColumnOrName', max: 'ColumnOrName', numBucket: Union[ForwardRef('ColumnOrName'), int]) -> pyspark.sql.connect.column.Column
 func WidthBucket(v column.Column, min column.Column, max column.Column, numBucket column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("width_bucket", v, min, max, numBucket))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("width_bucket", v, min, max, numBucket))
 }
 
 // Pow - Returns the value of the first argument raised to the power of the second argument.
 //
 // Pow is the Golang equivalent of pow: (col1: Union[ForwardRef('ColumnOrName'), float], col2: Union[ForwardRef('ColumnOrName'), float]) -> pyspark.sql.connect.column.Column
 func Pow(col1 column.Column, col2 column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("pow", col1, col2))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("pow", col1, col2))
 }
 
 // Radians - Converts an angle measured in degrees to an approximately equivalent angle
@@ -486,7 +485,7 @@ func Pow(col1 column.Column, col2 column.Column) column.Column {
 //
 // Radians is the Golang equivalent of radians: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Radians(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("radians", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("radians", col))
 }
 
 // Rint - Returns the double value that is closest in value to the argument and
@@ -494,7 +493,7 @@ func Radians(col column.Column) column.Column {
 //
 // Rint is the Golang equivalent of rint: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Rint(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("rint", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("rint", col))
 }
 
 // Round - Round the given value to `scale` decimal places using HALF_UP rounding mode if `scale` >= 0
@@ -502,98 +501,98 @@ func Rint(col column.Column) column.Column {
 //
 // Round is the Golang equivalent of round: (col: 'ColumnOrName', scale: int = 0) -> pyspark.sql.connect.column.Column
 func Round(col column.Column, scale int64) column.Column {
-    lit_scale := Int64Lit(scale)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("round", col, lit_scale))
+	lit_scale := Int64Lit(scale)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("round", col, lit_scale))
 }
 
 // Sec - Computes secant of the input column.
 //
 // Sec is the Golang equivalent of sec: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Sec(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sec", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sec", col))
 }
 
 // ShiftLeft - Shift the given value numBits left.
 //
 // ShiftLeft is the Golang equivalent of shiftLeft: (col: 'ColumnOrName', numBits: int) -> pyspark.sql.connect.column.Column
 func ShiftLeft(col column.Column, numBits int64) column.Column {
-    lit_numBits := Int64Lit(numBits)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("shiftLeft", col, lit_numBits))
+	lit_numBits := Int64Lit(numBits)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("shiftLeft", col, lit_numBits))
 }
 
 // Shiftleft - Shift the given value numBits left.
 //
 // Shiftleft is the Golang equivalent of shiftleft: (col: 'ColumnOrName', numBits: int) -> pyspark.sql.connect.column.Column
 func Shiftleft(col column.Column, numBits int64) column.Column {
-    lit_numBits := Int64Lit(numBits)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("shiftleft", col, lit_numBits))
+	lit_numBits := Int64Lit(numBits)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("shiftleft", col, lit_numBits))
 }
 
 // ShiftRight - (Signed) shift the given value numBits right.
 //
 // ShiftRight is the Golang equivalent of shiftRight: (col: 'ColumnOrName', numBits: int) -> pyspark.sql.connect.column.Column
 func ShiftRight(col column.Column, numBits int64) column.Column {
-    lit_numBits := Int64Lit(numBits)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("shiftRight", col, lit_numBits))
+	lit_numBits := Int64Lit(numBits)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("shiftRight", col, lit_numBits))
 }
 
 // Shiftright - (Signed) shift the given value numBits right.
 //
 // Shiftright is the Golang equivalent of shiftright: (col: 'ColumnOrName', numBits: int) -> pyspark.sql.connect.column.Column
 func Shiftright(col column.Column, numBits int64) column.Column {
-    lit_numBits := Int64Lit(numBits)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("shiftright", col, lit_numBits))
+	lit_numBits := Int64Lit(numBits)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("shiftright", col, lit_numBits))
 }
 
 // ShiftRightUnsigned - Unsigned shift the given value numBits right.
 //
 // ShiftRightUnsigned is the Golang equivalent of shiftRightUnsigned: (col: 'ColumnOrName', numBits: int) -> pyspark.sql.connect.column.Column
 func ShiftRightUnsigned(col column.Column, numBits int64) column.Column {
-    lit_numBits := Int64Lit(numBits)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("shiftRightUnsigned", col, lit_numBits))
+	lit_numBits := Int64Lit(numBits)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("shiftRightUnsigned", col, lit_numBits))
 }
 
 // Shiftrightunsigned - Unsigned shift the given value numBits right.
 //
 // Shiftrightunsigned is the Golang equivalent of shiftrightunsigned: (col: 'ColumnOrName', numBits: int) -> pyspark.sql.connect.column.Column
 func Shiftrightunsigned(col column.Column, numBits int64) column.Column {
-    lit_numBits := Int64Lit(numBits)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("shiftrightunsigned", col, lit_numBits))
+	lit_numBits := Int64Lit(numBits)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("shiftrightunsigned", col, lit_numBits))
 }
 
 // Signum - Computes the signum of the given value.
 //
 // Signum is the Golang equivalent of signum: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Signum(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("signum", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("signum", col))
 }
 
 // Sign - Computes the signum of the given value.
 //
 // Sign is the Golang equivalent of sign: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Sign(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sign", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sign", col))
 }
 
 // Sin - Computes sine of the input column.
 //
 // Sin is the Golang equivalent of sin: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Sin(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sin", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sin", col))
 }
 
 // Sinh - Computes hyperbolic sine of the input column.
 //
 // Sinh is the Golang equivalent of sinh: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Sinh(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sinh", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sinh", col))
 }
 
 // Sqrt - Computes the square root of the specified float value.
 //
 // Sqrt is the Golang equivalent of sqrt: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Sqrt(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sqrt", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sqrt", col))
 }
 
 // TryAdd - Returns the sum of `left`and `right` and the result is null on overflow.
@@ -601,14 +600,14 @@ func Sqrt(col column.Column) column.Column {
 //
 // TryAdd is the Golang equivalent of try_add: (left: 'ColumnOrName', right: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func TryAdd(left column.Column, right column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_add", left, right))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_add", left, right))
 }
 
 // TryAvg - Returns the mean calculated from values of a group and the result is null on overflow.
 //
 // TryAvg is the Golang equivalent of try_avg: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func TryAvg(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_avg", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_avg", col))
 }
 
 // TryDivide - Returns `dividend`/`divisor`. It always performs floating point division. Its result is
@@ -616,7 +615,7 @@ func TryAvg(col column.Column) column.Column {
 //
 // TryDivide is the Golang equivalent of try_divide: (left: 'ColumnOrName', right: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func TryDivide(left column.Column, right column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_divide", left, right))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_divide", left, right))
 }
 
 // TryMultiply - Returns `left`*`right` and the result is null on overflow. The acceptable input types are the
@@ -624,7 +623,7 @@ func TryDivide(left column.Column, right column.Column) column.Column {
 //
 // TryMultiply is the Golang equivalent of try_multiply: (left: 'ColumnOrName', right: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func TryMultiply(left column.Column, right column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_multiply", left, right))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_multiply", left, right))
 }
 
 // TrySubtract - Returns `left`-`right` and the result is null on overflow. The acceptable input types are the
@@ -632,42 +631,42 @@ func TryMultiply(left column.Column, right column.Column) column.Column {
 //
 // TrySubtract is the Golang equivalent of try_subtract: (left: 'ColumnOrName', right: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func TrySubtract(left column.Column, right column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_subtract", left, right))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_subtract", left, right))
 }
 
 // TrySum - Returns the sum calculated from values of a group and the result is null on overflow.
 //
 // TrySum is the Golang equivalent of try_sum: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func TrySum(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_sum", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_sum", col))
 }
 
 // Tan - Computes tangent of the input column.
 //
 // Tan is the Golang equivalent of tan: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Tan(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("tan", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("tan", col))
 }
 
 // Tanh - Computes hyperbolic tangent of the input column.
 //
 // Tanh is the Golang equivalent of tanh: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Tanh(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("tanh", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("tanh", col))
 }
 
-// ToDegrees - 
+// ToDegrees -
 //
 // ToDegrees is the Golang equivalent of toDegrees: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func ToDegrees(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("toDegrees", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("toDegrees", col))
 }
 
-// ToRadians - 
+// ToRadians -
 //
 // ToRadians is the Golang equivalent of toRadians: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func ToRadians(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("toRadians", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("toRadians", col))
 }
 
 // Unhex - Inverse of hex. Interprets each pair of characters as a hexadecimal number
@@ -675,7 +674,7 @@ func ToRadians(col column.Column) column.Column {
 //
 // Unhex is the Golang equivalent of unhex: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Unhex(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("unhex", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("unhex", col))
 }
 
 // ApproxCountDistinct - Aggregate function: returns a new :class:`~pyspark.sql.Column` for approximate distinct count
@@ -683,77 +682,77 @@ func Unhex(col column.Column) column.Column {
 //
 // ApproxCountDistinct is the Golang equivalent of approx_count_distinct: (col: 'ColumnOrName', rsd: Optional[float] = None) -> pyspark.sql.connect.column.Column
 func ApproxCountDistinct(col column.Column, rsd float64) column.Column {
-    lit_rsd := Float64Lit(rsd)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("approx_count_distinct", col, lit_rsd))
+	lit_rsd := Float64Lit(rsd)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("approx_count_distinct", col, lit_rsd))
 }
 
 // Avg - Aggregate function: returns the average of the values in a group.
 //
 // Avg is the Golang equivalent of avg: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Avg(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("avg", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("avg", col))
 }
 
 // CollectList - Aggregate function: returns a list of objects with duplicates.
 //
 // CollectList is the Golang equivalent of collect_list: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func CollectList(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("collect_list", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("collect_list", col))
 }
 
 // ArrayAgg - Aggregate function: returns a list of objects with duplicates.
 //
 // ArrayAgg is the Golang equivalent of array_agg: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func ArrayAgg(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_agg", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_agg", col))
 }
 
 // CollectSet - Aggregate function: returns a set of objects with duplicate elements eliminated.
 //
 // CollectSet is the Golang equivalent of collect_set: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func CollectSet(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("collect_set", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("collect_set", col))
 }
 
 // Corr - Returns a new :class:`~pyspark.sql.Column` for the Pearson Correlation Coefficient for
-// ``col1`` and ``col2``.
+// “col1“ and “col2“.
 //
 // Corr is the Golang equivalent of corr: (col1: 'ColumnOrName', col2: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Corr(col1 column.Column, col2 column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("corr", col1, col2))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("corr", col1, col2))
 }
 
 // Count - Aggregate function: returns the number of items in a group.
 //
 // Count is the Golang equivalent of count: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Count(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("count", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("count", col))
 }
 
-// CountDistinct - Returns a new :class:`Column` for distinct count of ``col`` or ``cols``.
+// CountDistinct - Returns a new :class:`Column` for distinct count of “col“ or “cols“.
 //
 // CountDistinct is the Golang equivalent of count_distinct: (col: 'ColumnOrName', *cols: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func CountDistinct(col column.Column, cols ...column.Column) column.Column {
-    vals := make([]column.Column, 0)
-    vals = append(vals, col)
-    vals = append(vals, cols...)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("count_distinct", vals...))
+	vals := make([]column.Column, 0)
+	vals = append(vals, col)
+	vals = append(vals, cols...)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("count_distinct", vals...))
 }
 
-// CovarPop - Returns a new :class:`~pyspark.sql.Column` for the population covariance of ``col1`` and
-// ``col2``.
+// CovarPop - Returns a new :class:`~pyspark.sql.Column` for the population covariance of “col1“ and
+// “col2“.
 //
 // CovarPop is the Golang equivalent of covar_pop: (col1: 'ColumnOrName', col2: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func CovarPop(col1 column.Column, col2 column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("covar_pop", col1, col2))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("covar_pop", col1, col2))
 }
 
-// CovarSamp - Returns a new :class:`~pyspark.sql.Column` for the sample covariance of ``col1`` and
-// ``col2``.
+// CovarSamp - Returns a new :class:`~pyspark.sql.Column` for the sample covariance of “col1“ and
+// “col2“.
 //
 // CovarSamp is the Golang equivalent of covar_samp: (col1: 'ColumnOrName', col2: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func CovarSamp(col1 column.Column, col2 column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("covar_samp", col1, col2))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("covar_samp", col1, col2))
 }
 
 // TODO: first: (col: 'ColumnOrName', ignorenulls: bool = False) -> pyspark.sql.connect.column.Column
@@ -763,18 +762,18 @@ func CovarSamp(col1 column.Column, col2 column.Column) column.Column {
 //
 // Grouping is the Golang equivalent of grouping: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Grouping(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("grouping", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("grouping", col))
 }
 
 // GroupingId - Aggregate function: returns the level of grouping, equals to
-// 
+//
 // (grouping(c1) << (n-1)) + (grouping(c2) << (n-2)) + ... + grouping(cn)
 //
 // GroupingId is the Golang equivalent of grouping_id: (*cols: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func GroupingId(cols ...column.Column) column.Column {
-    vals := make([]column.Column, 0)
-    vals = append(vals, cols...)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("grouping_id", vals...))
+	vals := make([]column.Column, 0)
+	vals = append(vals, cols...)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("grouping_id", vals...))
 }
 
 // CountMinSketch - Returns a count-min sketch of a column with the given esp, confidence and seed.
@@ -784,14 +783,14 @@ func GroupingId(cols ...column.Column) column.Column {
 //
 // CountMinSketch is the Golang equivalent of count_min_sketch: (col: 'ColumnOrName', eps: 'ColumnOrName', confidence: 'ColumnOrName', seed: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func CountMinSketch(col column.Column, eps column.Column, confidence column.Column, seed column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("count_min_sketch", col, eps, confidence, seed))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("count_min_sketch", col, eps, confidence, seed))
 }
 
 // Kurtosis - Aggregate function: returns the kurtosis of the values in a group.
 //
 // Kurtosis is the Golang equivalent of kurtosis: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Kurtosis(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("kurtosis", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("kurtosis", col))
 }
 
 // TODO: last: (col: 'ColumnOrName', ignorenulls: bool = False) -> pyspark.sql.connect.column.Column
@@ -800,14 +799,14 @@ func Kurtosis(col column.Column) column.Column {
 //
 // Max is the Golang equivalent of max: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Max(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("max", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("max", col))
 }
 
 // MaxBy - Returns the value associated with the maximum value of ord.
 //
 // MaxBy is the Golang equivalent of max_by: (col: 'ColumnOrName', ord: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func MaxBy(col column.Column, ord column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("max_by", col, ord))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("max_by", col, ord))
 }
 
 // Mean - Aggregate function: returns the average of the values in a group.
@@ -815,35 +814,35 @@ func MaxBy(col column.Column, ord column.Column) column.Column {
 //
 // Mean is the Golang equivalent of mean: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Mean(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("mean", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("mean", col))
 }
 
 // Median - Returns the median of the values in a group.
 //
 // Median is the Golang equivalent of median: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Median(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("median", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("median", col))
 }
 
 // Min - Aggregate function: returns the minimum value of the expression in a group.
 //
 // Min is the Golang equivalent of min: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Min(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("min", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("min", col))
 }
 
 // MinBy - Returns the value associated with the minimum value of ord.
 //
 // MinBy is the Golang equivalent of min_by: (col: 'ColumnOrName', ord: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func MinBy(col column.Column, ord column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("min_by", col, ord))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("min_by", col, ord))
 }
 
 // Mode - Returns the most frequent value in a group.
 //
 // Mode is the Golang equivalent of mode: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Mode(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("mode", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("mode", col))
 }
 
 // TODO: percentile: (col: 'ColumnOrName', percentage: Union[pyspark.sql.connect.column.Column, float, List[float], Tuple[float]], frequency: Union[pyspark.sql.connect.column.Column, int] = 1) -> pyspark.sql.connect.column.Column
@@ -856,28 +855,28 @@ func Mode(col column.Column) column.Column {
 //
 // Product is the Golang equivalent of product: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Product(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("product", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("product", col))
 }
 
 // Skewness - Aggregate function: returns the skewness of the values in a group.
 //
 // Skewness is the Golang equivalent of skewness: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Skewness(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("skewness", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("skewness", col))
 }
 
 // Stddev - Aggregate function: alias for stddev_samp.
 //
 // Stddev is the Golang equivalent of stddev: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Stddev(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("stddev", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("stddev", col))
 }
 
 // Std - Aggregate function: alias for stddev_samp.
 //
 // Std is the Golang equivalent of std: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Std(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("std", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("std", col))
 }
 
 // StddevSamp - Aggregate function: returns the unbiased sample standard deviation of
@@ -885,7 +884,7 @@ func Std(col column.Column) column.Column {
 //
 // StddevSamp is the Golang equivalent of stddev_samp: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func StddevSamp(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("stddev_samp", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("stddev_samp", col))
 }
 
 // StddevPop - Aggregate function: returns population standard deviation of
@@ -893,28 +892,28 @@ func StddevSamp(col column.Column) column.Column {
 //
 // StddevPop is the Golang equivalent of stddev_pop: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func StddevPop(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("stddev_pop", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("stddev_pop", col))
 }
 
 // Sum - Aggregate function: returns the sum of all values in the expression.
 //
 // Sum is the Golang equivalent of sum: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Sum(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sum", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sum", col))
 }
 
 // SumDistinct - Aggregate function: returns the sum of distinct values in the expression.
 //
 // SumDistinct is the Golang equivalent of sum_distinct: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func SumDistinct(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sum_distinct", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sum_distinct", col))
 }
 
 // VarPop - Aggregate function: returns the population variance of the values in a group.
 //
 // VarPop is the Golang equivalent of var_pop: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func VarPop(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("var_pop", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("var_pop", col))
 }
 
 // RegrAvgx - Aggregate function: returns the average of the independent variable for non-null pairs
@@ -922,7 +921,7 @@ func VarPop(col column.Column) column.Column {
 //
 // RegrAvgx is the Golang equivalent of regr_avgx: (y: 'ColumnOrName', x: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func RegrAvgx(y column.Column, x column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regr_avgx", y, x))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regr_avgx", y, x))
 }
 
 // RegrAvgy - Aggregate function: returns the average of the dependent variable for non-null pairs
@@ -930,7 +929,7 @@ func RegrAvgx(y column.Column, x column.Column) column.Column {
 //
 // RegrAvgy is the Golang equivalent of regr_avgy: (y: 'ColumnOrName', x: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func RegrAvgy(y column.Column, x column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regr_avgy", y, x))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regr_avgy", y, x))
 }
 
 // RegrCount - Aggregate function: returns the number of non-null number pairs
@@ -938,7 +937,7 @@ func RegrAvgy(y column.Column, x column.Column) column.Column {
 //
 // RegrCount is the Golang equivalent of regr_count: (y: 'ColumnOrName', x: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func RegrCount(y column.Column, x column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regr_count", y, x))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regr_count", y, x))
 }
 
 // RegrIntercept - Aggregate function: returns the intercept of the univariate linear regression line
@@ -947,7 +946,7 @@ func RegrCount(y column.Column, x column.Column) column.Column {
 //
 // RegrIntercept is the Golang equivalent of regr_intercept: (y: 'ColumnOrName', x: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func RegrIntercept(y column.Column, x column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regr_intercept", y, x))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regr_intercept", y, x))
 }
 
 // RegrR2 - Aggregate function: returns the coefficient of determination for non-null pairs
@@ -955,7 +954,7 @@ func RegrIntercept(y column.Column, x column.Column) column.Column {
 //
 // RegrR2 is the Golang equivalent of regr_r2: (y: 'ColumnOrName', x: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func RegrR2(y column.Column, x column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regr_r2", y, x))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regr_r2", y, x))
 }
 
 // RegrSlope - Aggregate function: returns the slope of the linear regression line for non-null pairs
@@ -963,7 +962,7 @@ func RegrR2(y column.Column, x column.Column) column.Column {
 //
 // RegrSlope is the Golang equivalent of regr_slope: (y: 'ColumnOrName', x: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func RegrSlope(y column.Column, x column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regr_slope", y, x))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regr_slope", y, x))
 }
 
 // RegrSxx - Aggregate function: returns REGR_COUNT(y, x) * VAR_POP(x) for non-null pairs
@@ -971,7 +970,7 @@ func RegrSlope(y column.Column, x column.Column) column.Column {
 //
 // RegrSxx is the Golang equivalent of regr_sxx: (y: 'ColumnOrName', x: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func RegrSxx(y column.Column, x column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regr_sxx", y, x))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regr_sxx", y, x))
 }
 
 // RegrSxy - Aggregate function: returns REGR_COUNT(y, x) * COVAR_POP(y, x) for non-null pairs
@@ -979,7 +978,7 @@ func RegrSxx(y column.Column, x column.Column) column.Column {
 //
 // RegrSxy is the Golang equivalent of regr_sxy: (y: 'ColumnOrName', x: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func RegrSxy(y column.Column, x column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regr_sxy", y, x))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regr_sxy", y, x))
 }
 
 // RegrSyy - Aggregate function: returns REGR_COUNT(y, x) * VAR_POP(y) for non-null pairs
@@ -987,7 +986,7 @@ func RegrSxy(y column.Column, x column.Column) column.Column {
 //
 // RegrSyy is the Golang equivalent of regr_syy: (y: 'ColumnOrName', x: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func RegrSyy(y column.Column, x column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regr_syy", y, x))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regr_syy", y, x))
 }
 
 // VarSamp - Aggregate function: returns the unbiased sample variance of
@@ -995,63 +994,63 @@ func RegrSyy(y column.Column, x column.Column) column.Column {
 //
 // VarSamp is the Golang equivalent of var_samp: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func VarSamp(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("var_samp", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("var_samp", col))
 }
 
 // Variance - Aggregate function: alias for var_samp
 //
 // Variance is the Golang equivalent of variance: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Variance(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("variance", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("variance", col))
 }
 
 // Every - Aggregate function: returns true if all values of `col` are true.
 //
 // Every is the Golang equivalent of every: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Every(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("every", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("every", col))
 }
 
 // BoolAnd - Aggregate function: returns true if all values of `col` are true.
 //
 // BoolAnd is the Golang equivalent of bool_and: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func BoolAnd(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bool_and", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bool_and", col))
 }
 
 // Some - Aggregate function: returns true if at least one value of `col` is true.
 //
 // Some is the Golang equivalent of some: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Some(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("some", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("some", col))
 }
 
 // BoolOr - Aggregate function: returns true if at least one value of `col` is true.
 //
 // BoolOr is the Golang equivalent of bool_or: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func BoolOr(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bool_or", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bool_or", col))
 }
 
 // BitAnd - Aggregate function: returns the bitwise AND of all non-null input values, or null if none.
 //
 // BitAnd is the Golang equivalent of bit_and: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func BitAnd(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bit_and", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bit_and", col))
 }
 
 // BitOr - Aggregate function: returns the bitwise OR of all non-null input values, or null if none.
 //
 // BitOr is the Golang equivalent of bit_or: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func BitOr(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bit_or", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bit_or", col))
 }
 
 // BitXor - Aggregate function: returns the bitwise XOR of all non-null input values, or null if none.
 //
 // BitXor is the Golang equivalent of bit_xor: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func BitXor(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bit_xor", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bit_xor", col))
 }
 
 // CumeDist - Window function: returns the cumulative distribution of values within a window partition,
@@ -1059,22 +1058,22 @@ func BitXor(col column.Column) column.Column {
 //
 // CumeDist is the Golang equivalent of cume_dist: () -> pyspark.sql.connect.column.Column
 func CumeDist() column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("cume_dist", ))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("cume_dist"))
 }
 
 // DenseRank - Window function: returns the rank of rows within a window partition, without any gaps.
-// 
+//
 // The difference between rank and dense_rank is that dense_rank leaves no gaps in ranking
 // sequence when there are ties. That is, if you were ranking a competition using dense_rank
 // and had three people tie for second place, you would say that all three were in second
 // place and that the next person came in third. Rank would give me sequential numbers, making
 // the person that came in third place (after the ties) would register as coming in fifth.
-// 
+//
 // This is equivalent to the DENSE_RANK function in SQL.
 //
 // DenseRank is the Golang equivalent of dense_rank: () -> pyspark.sql.connect.column.Column
 func DenseRank() column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("dense_rank", ))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("dense_rank"))
 }
 
 // TODO: lag: (col: 'ColumnOrName', offset: int = 1, default: Optional[Any] = None) -> pyspark.sql.connect.column.Column
@@ -1093,7 +1092,7 @@ func DenseRank() column.Column {
 //
 // CountIf is the Golang equivalent of count_if: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func CountIf(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("count_if", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("count_if", col))
 }
 
 // HistogramNumeric - Computes a histogram on numeric 'col' using nb bins.
@@ -1109,49 +1108,49 @@ func CountIf(col column.Column) column.Column {
 //
 // HistogramNumeric is the Golang equivalent of histogram_numeric: (col: 'ColumnOrName', nBins: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func HistogramNumeric(col column.Column, nBins column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("histogram_numeric", col, nBins))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("histogram_numeric", col, nBins))
 }
 
 // Ntile - Window function: returns the ntile group id (from 1 to `n` inclusive)
 // in an ordered window partition. For example, if `n` is 4, the first
 // quarter of the rows will get value 1, the second quarter will get 2,
 // the third quarter will get 3, and the last quarter will get 4.
-// 
+//
 // This is equivalent to the NTILE function in SQL.
 //
 // Ntile is the Golang equivalent of ntile: (n: int) -> pyspark.sql.connect.column.Column
 func Ntile(n int64) column.Column {
-    lit_n := Int64Lit(n)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("ntile", lit_n))
+	lit_n := Int64Lit(n)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("ntile", lit_n))
 }
 
 // PercentRank - Window function: returns the relative rank (i.e. percentile) of rows within a window partition.
 //
 // PercentRank is the Golang equivalent of percent_rank: () -> pyspark.sql.connect.column.Column
 func PercentRank() column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("percent_rank", ))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("percent_rank"))
 }
 
 // Rank - Window function: returns the rank of rows within a window partition.
-// 
+//
 // The difference between rank and dense_rank is that dense_rank leaves no gaps in ranking
 // sequence when there are ties. That is, if you were ranking a competition using dense_rank
 // and had three people tie for second place, you would say that all three were in second
 // place and that the next person came in third. Rank would give me sequential numbers, making
 // the person that came in third place (after the ties) would register as coming in fifth.
-// 
+//
 // This is equivalent to the RANK function in SQL.
 //
 // Rank is the Golang equivalent of rank: () -> pyspark.sql.connect.column.Column
 func Rank() column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("rank", ))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("rank"))
 }
 
 // RowNumber - Window function: returns a sequential number starting at 1 within a window partition.
 //
 // RowNumber is the Golang equivalent of row_number: () -> pyspark.sql.connect.column.Column
 func RowNumber() column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("row_number", ))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("row_number"))
 }
 
 // TODO: aggregate: (col: 'ColumnOrName', initialValue: 'ColumnOrName', merge: Callable[[pyspark.sql.connect.column.Column, pyspark.sql.connect.column.Column], pyspark.sql.connect.column.Column], finish: Optional[Callable[[pyspark.sql.connect.column.Column], pyspark.sql.connect.column.Column]] = None) -> pyspark.sql.connect.column.Column
@@ -1162,7 +1161,7 @@ func RowNumber() column.Column {
 //
 // Array is the Golang equivalent of array: (*cols: Union[ForwardRef('ColumnOrName'), List[ForwardRef('ColumnOrName')], Tuple[ForwardRef('ColumnOrName'), ...]]) -> pyspark.sql.connect.column.Column
 func Array(cols column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array", cols))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array", cols))
 }
 
 // TODO: array_append: (col: 'ColumnOrName', value: Any) -> pyspark.sql.connect.column.Column
@@ -1173,7 +1172,7 @@ func Array(cols column.Column) column.Column {
 //
 // ArrayDistinct is the Golang equivalent of array_distinct: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func ArrayDistinct(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_distinct", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_distinct", col))
 }
 
 // ArrayExcept - Collection function: returns an array of the elements in col1 but not in col2,
@@ -1181,7 +1180,7 @@ func ArrayDistinct(col column.Column) column.Column {
 //
 // ArrayExcept is the Golang equivalent of array_except: (col1: 'ColumnOrName', col2: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func ArrayExcept(col1 column.Column, col2 column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_except", col1, col2))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_except", col1, col2))
 }
 
 // TODO: array_insert: (arr: 'ColumnOrName', pos: Union[ForwardRef('ColumnOrName'), int], value: Any) -> pyspark.sql.connect.column.Column
@@ -1191,14 +1190,14 @@ func ArrayExcept(col1 column.Column, col2 column.Column) column.Column {
 //
 // ArrayIntersect is the Golang equivalent of array_intersect: (col1: 'ColumnOrName', col2: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func ArrayIntersect(col1 column.Column, col2 column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_intersect", col1, col2))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_intersect", col1, col2))
 }
 
 // ArrayCompact - Collection function: removes null values from the array.
 //
 // ArrayCompact is the Golang equivalent of array_compact: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func ArrayCompact(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_compact", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_compact", col))
 }
 
 // ArrayJoin - Concatenates the elements of `column` using the `delimiter`. Null values are replaced with
@@ -1206,37 +1205,37 @@ func ArrayCompact(col column.Column) column.Column {
 //
 // ArrayJoin is the Golang equivalent of array_join: (col: 'ColumnOrName', delimiter: str, null_replacement: Optional[str] = None) -> pyspark.sql.connect.column.Column
 func ArrayJoin(col column.Column, delimiter string, null_replacement string) column.Column {
-    lit_delimiter := StringLit(delimiter)
-    lit_null_replacement := StringLit(null_replacement)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_join", col, lit_delimiter, lit_null_replacement))
+	lit_delimiter := StringLit(delimiter)
+	lit_null_replacement := StringLit(null_replacement)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_join", col, lit_delimiter, lit_null_replacement))
 }
 
 // ArrayMax - Collection function: returns the maximum value of the array.
 //
 // ArrayMax is the Golang equivalent of array_max: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func ArrayMax(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_max", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_max", col))
 }
 
 // ArrayMin - Collection function: returns the minimum value of the array.
 //
 // ArrayMin is the Golang equivalent of array_min: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func ArrayMin(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_min", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_min", col))
 }
 
 // ArraySize - Returns the total number of elements in the array. The function returns null for null input.
 //
 // ArraySize is the Golang equivalent of array_size: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func ArraySize(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_size", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_size", col))
 }
 
 // Cardinality - Collection function: returns the length of the array or map stored in the column.
 //
 // Cardinality is the Golang equivalent of cardinality: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Cardinality(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("cardinality", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("cardinality", col))
 }
 
 // TODO: array_position: (col: 'ColumnOrName', value: Any) -> pyspark.sql.connect.column.Column
@@ -1249,7 +1248,7 @@ func Cardinality(col column.Column) column.Column {
 //
 // ArrayRepeat is the Golang equivalent of array_repeat: (col: 'ColumnOrName', count: Union[ForwardRef('ColumnOrName'), int]) -> pyspark.sql.connect.column.Column
 func ArrayRepeat(col column.Column, count column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_repeat", col, count))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_repeat", col, count))
 }
 
 // TODO: array_sort: (col: 'ColumnOrName', comparator: Optional[Callable[[pyspark.sql.connect.column.Column, pyspark.sql.connect.column.Column], pyspark.sql.connect.column.Column]] = None) -> pyspark.sql.connect.column.Column
@@ -1259,7 +1258,7 @@ func ArrayRepeat(col column.Column, count column.Column) column.Column {
 //
 // ArrayUnion is the Golang equivalent of array_union: (col1: 'ColumnOrName', col2: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func ArrayUnion(col1 column.Column, col2 column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_union", col1, col2))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("array_union", col1, col2))
 }
 
 // ArraysOverlap - Collection function: returns true if the arrays contain any common non-null element; if not,
@@ -1268,7 +1267,7 @@ func ArrayUnion(col1 column.Column, col2 column.Column) column.Column {
 //
 // ArraysOverlap is the Golang equivalent of arrays_overlap: (a1: 'ColumnOrName', a2: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func ArraysOverlap(a1 column.Column, a2 column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("arrays_overlap", a1, a2))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("arrays_overlap", a1, a2))
 }
 
 // ArraysZip - Collection function: Returns a merged array of structs in which the N-th struct contains all
@@ -1277,9 +1276,9 @@ func ArraysOverlap(a1 column.Column, a2 column.Column) column.Column {
 //
 // ArraysZip is the Golang equivalent of arrays_zip: (*cols: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func ArraysZip(cols ...column.Column) column.Column {
-    vals := make([]column.Column, 0)
-    vals = append(vals, cols...)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("arrays_zip", vals...))
+	vals := make([]column.Column, 0)
+	vals = append(vals, cols...)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("arrays_zip", vals...))
 }
 
 // Concat - Concatenates multiple input columns together into a single column.
@@ -1287,16 +1286,16 @@ func ArraysZip(cols ...column.Column) column.Column {
 //
 // Concat is the Golang equivalent of concat: (*cols: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Concat(cols ...column.Column) column.Column {
-    vals := make([]column.Column, 0)
-    vals = append(vals, cols...)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("concat", vals...))
+	vals := make([]column.Column, 0)
+	vals = append(vals, cols...)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("concat", vals...))
 }
 
 // CreateMap - Creates a new map column.
 //
 // CreateMap is the Golang equivalent of create_map: (*cols: Union[ForwardRef('ColumnOrName'), List[ForwardRef('ColumnOrName')], Tuple[ForwardRef('ColumnOrName'), ...]]) -> pyspark.sql.connect.column.Column
 func CreateMap(cols column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("create_map", cols))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("create_map", cols))
 }
 
 // TODO: element_at: (col: 'ColumnOrName', extraction: Any) -> pyspark.sql.connect.column.Column
@@ -1304,13 +1303,13 @@ func CreateMap(cols column.Column) column.Column {
 // TryElementAt - (array, index) - Returns element of array at given (1-based) index. If Index is 0, Spark will
 // throw an error. If index < 0, accesses elements from the last to the first. The function
 // always returns NULL if the index exceeds the length of the array.
-// 
+//
 // (map, key) - Returns value for given key. The function always returns NULL if the key is not
 // contained in the map.
 //
 // TryElementAt is the Golang equivalent of try_element_at: (col: 'ColumnOrName', extraction: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func TryElementAt(col column.Column, extraction column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_element_at", col, extraction))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_element_at", col, extraction))
 }
 
 // TODO: exists: (col: 'ColumnOrName', f: Callable[[pyspark.sql.connect.column.Column], pyspark.sql.connect.column.Column]) -> pyspark.sql.connect.column.Column
@@ -1321,7 +1320,7 @@ func TryElementAt(col column.Column, extraction column.Column) column.Column {
 //
 // Explode is the Golang equivalent of explode: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Explode(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("explode", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("explode", col))
 }
 
 // ExplodeOuter - Returns a new row for each element in the given array or map.
@@ -1331,7 +1330,7 @@ func Explode(col column.Column) column.Column {
 //
 // ExplodeOuter is the Golang equivalent of explode_outer: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func ExplodeOuter(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("explode_outer", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("explode_outer", col))
 }
 
 // TODO: filter: (col: 'ColumnOrName', f: Union[Callable[[pyspark.sql.connect.column.Column], pyspark.sql.connect.column.Column], Callable[[pyspark.sql.connect.column.Column, pyspark.sql.connect.column.Column], pyspark.sql.connect.column.Column]]) -> pyspark.sql.connect.column.Column
@@ -1342,7 +1341,7 @@ func ExplodeOuter(col column.Column) column.Column {
 //
 // Flatten is the Golang equivalent of flatten: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Flatten(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("flatten", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("flatten", col))
 }
 
 // TODO: forall: (col: 'ColumnOrName', f: Callable[[pyspark.sql.connect.column.Column], pyspark.sql.connect.column.Column]) -> pyspark.sql.connect.column.Column
@@ -1357,7 +1356,7 @@ func Flatten(col column.Column) column.Column {
 //
 // Get is the Golang equivalent of get: (col: 'ColumnOrName', index: Union[ForwardRef('ColumnOrName'), int]) -> pyspark.sql.connect.column.Column
 func Get(col column.Column, index column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("get", col, index))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("get", col, index))
 }
 
 // GetJsonObject - Extracts json object from a json string based on json `path` specified, and returns json string
@@ -1365,8 +1364,8 @@ func Get(col column.Column, index column.Column) column.Column {
 //
 // GetJsonObject is the Golang equivalent of get_json_object: (col: 'ColumnOrName', path: str) -> pyspark.sql.connect.column.Column
 func GetJsonObject(col column.Column, path string) column.Column {
-    lit_path := StringLit(path)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("get_json_object", col, lit_path))
+	lit_path := StringLit(path)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("get_json_object", col, lit_path))
 }
 
 // JsonArrayLength - Returns the number of elements in the outermost JSON array. `NULL` is returned in case of
@@ -1374,7 +1373,7 @@ func GetJsonObject(col column.Column, path string) column.Column {
 //
 // JsonArrayLength is the Golang equivalent of json_array_length: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func JsonArrayLength(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("json_array_length", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("json_array_length", col))
 }
 
 // JsonObjectKeys - Returns all the keys of the outermost JSON object as an array. If a valid JSON object is
@@ -1383,14 +1382,14 @@ func JsonArrayLength(col column.Column) column.Column {
 //
 // JsonObjectKeys is the Golang equivalent of json_object_keys: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func JsonObjectKeys(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("json_object_keys", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("json_object_keys", col))
 }
 
 // Inline - Explodes an array of structs into a table.
 //
 // Inline is the Golang equivalent of inline: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Inline(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("inline", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("inline", col))
 }
 
 // InlineOuter - Explodes an array of structs into a table.
@@ -1398,22 +1397,22 @@ func Inline(col column.Column) column.Column {
 //
 // InlineOuter is the Golang equivalent of inline_outer: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func InlineOuter(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("inline_outer", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("inline_outer", col))
 }
 
 // JsonTuple - Creates a new row for a json column according to the given field names.
 //
 // JsonTuple is the Golang equivalent of json_tuple: (col: 'ColumnOrName', *fields: str) -> pyspark.sql.connect.column.Column
 func JsonTuple(col column.Column, fields string) column.Column {
-    lit_fields := StringLit(fields)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("json_tuple", col, lit_fields))
+	lit_fields := StringLit(fields)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("json_tuple", col, lit_fields))
 }
 
 // MapConcat - Returns the union of all the given maps.
 //
 // MapConcat is the Golang equivalent of map_concat: (*cols: Union[ForwardRef('ColumnOrName'), List[ForwardRef('ColumnOrName')], Tuple[ForwardRef('ColumnOrName'), ...]]) -> pyspark.sql.connect.column.Column
 func MapConcat(cols column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("map_concat", cols))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("map_concat", cols))
 }
 
 // TODO: map_contains_key: (col: 'ColumnOrName', value: Any) -> pyspark.sql.connect.column.Column
@@ -1422,7 +1421,7 @@ func MapConcat(cols column.Column) column.Column {
 //
 // MapEntries is the Golang equivalent of map_entries: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func MapEntries(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("map_entries", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("map_entries", col))
 }
 
 // TODO: map_filter: (col: 'ColumnOrName', f: Callable[[pyspark.sql.connect.column.Column, pyspark.sql.connect.column.Column], pyspark.sql.connect.column.Column]) -> pyspark.sql.connect.column.Column
@@ -1431,7 +1430,7 @@ func MapEntries(col column.Column) column.Column {
 //
 // MapFromArrays is the Golang equivalent of map_from_arrays: (col1: 'ColumnOrName', col2: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func MapFromArrays(col1 column.Column, col2 column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("map_from_arrays", col1, col2))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("map_from_arrays", col1, col2))
 }
 
 // MapFromEntries - Collection function: Converts an array of entries (key value struct types) to a map
@@ -1439,21 +1438,21 @@ func MapFromArrays(col1 column.Column, col2 column.Column) column.Column {
 //
 // MapFromEntries is the Golang equivalent of map_from_entries: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func MapFromEntries(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("map_from_entries", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("map_from_entries", col))
 }
 
 // MapKeys - Collection function: Returns an unordered array containing the keys of the map.
 //
 // MapKeys is the Golang equivalent of map_keys: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func MapKeys(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("map_keys", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("map_keys", col))
 }
 
 // MapValues - Collection function: Returns an unordered array containing the values of the map.
 //
 // MapValues is the Golang equivalent of map_values: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func MapValues(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("map_values", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("map_values", col))
 }
 
 // TODO: map_zip_with: (col1: 'ColumnOrName', col2: 'ColumnOrName', f: Callable[[pyspark.sql.connect.column.Column, pyspark.sql.connect.column.Column, pyspark.sql.connect.column.Column], pyspark.sql.connect.column.Column]) -> pyspark.sql.connect.column.Column
@@ -1463,7 +1462,7 @@ func MapValues(col column.Column) column.Column {
 //
 // StrToMap is the Golang equivalent of str_to_map: (text: 'ColumnOrName', pairDelim: Optional[ForwardRef('ColumnOrName')] = None, keyValueDelim: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
 func StrToMap(text column.Column, pairDelim column.Column, keyValueDelim column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("str_to_map", text, pairDelim, keyValueDelim))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("str_to_map", text, pairDelim, keyValueDelim))
 }
 
 // Posexplode - Returns a new row for each element with position in the given array or map.
@@ -1472,7 +1471,7 @@ func StrToMap(text column.Column, pairDelim column.Column, keyValueDelim column.
 //
 // Posexplode is the Golang equivalent of posexplode: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Posexplode(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("posexplode", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("posexplode", col))
 }
 
 // PosexplodeOuter - Returns a new row for each element with position in the given array or map.
@@ -1482,14 +1481,14 @@ func Posexplode(col column.Column) column.Column {
 //
 // PosexplodeOuter is the Golang equivalent of posexplode_outer: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func PosexplodeOuter(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("posexplode_outer", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("posexplode_outer", col))
 }
 
 // Reverse - Collection function: returns a reversed string or an array with reverse order of elements.
 //
 // Reverse is the Golang equivalent of reverse: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Reverse(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("reverse", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("reverse", col))
 }
 
 // Sequence - Generate a sequence of integers from `start` to `stop`, incrementing by `step`.
@@ -1498,7 +1497,7 @@ func Reverse(col column.Column) column.Column {
 //
 // Sequence is the Golang equivalent of sequence: (start: 'ColumnOrName', stop: 'ColumnOrName', step: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
 func Sequence(start column.Column, stop column.Column, step column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sequence", start, stop, step))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sequence", start, stop, step))
 }
 
 // TODO: schema_of_csv: (csv: 'ColumnOrName', options: Optional[Dict[str, str]] = None) -> pyspark.sql.connect.column.Column
@@ -1509,14 +1508,14 @@ func Sequence(start column.Column, stop column.Column, step column.Column) colum
 //
 // Shuffle is the Golang equivalent of shuffle: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Shuffle(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("shuffle", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("shuffle", col))
 }
 
 // Size - Collection function: returns the length of the array or map stored in the column.
 //
 // Size is the Golang equivalent of size: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Size(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("size", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("size", col))
 }
 
 // Slice - Collection function: returns an array containing all the elements in `x` from index `start`
@@ -1524,7 +1523,7 @@ func Size(col column.Column) column.Column {
 //
 // Slice is the Golang equivalent of slice: (col: 'ColumnOrName', start: Union[ForwardRef('ColumnOrName'), int], length: Union[ForwardRef('ColumnOrName'), int]) -> pyspark.sql.connect.column.Column
 func Slice(col column.Column, start column.Column, length column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("slice", col, start, length))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("slice", col, start, length))
 }
 
 // TODO: sort_array: (col: 'ColumnOrName', asc: bool = True) -> pyspark.sql.connect.column.Column
@@ -1533,16 +1532,16 @@ func Slice(col column.Column, start column.Column, length column.Column) column.
 //
 // Struct is the Golang equivalent of struct: (*cols: Union[ForwardRef('ColumnOrName'), List[ForwardRef('ColumnOrName')], Tuple[ForwardRef('ColumnOrName'), ...]]) -> pyspark.sql.connect.column.Column
 func Struct(cols column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("struct", cols))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("struct", cols))
 }
 
 // NamedStruct - Creates a struct with the given field names and values.
 //
 // NamedStruct is the Golang equivalent of named_struct: (*cols: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func NamedStruct(cols ...column.Column) column.Column {
-    vals := make([]column.Column, 0)
-    vals = append(vals, cols...)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("named_struct", vals...))
+	vals := make([]column.Column, 0)
+	vals = append(vals, cols...)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("named_struct", vals...))
 }
 
 // TODO: to_csv: (col: 'ColumnOrName', options: Optional[Dict[str, str]] = None) -> pyspark.sql.connect.column.Column
@@ -1561,56 +1560,56 @@ func NamedStruct(cols ...column.Column) column.Column {
 //
 // Upper is the Golang equivalent of upper: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Upper(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("upper", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("upper", col))
 }
 
 // Lower - Converts a string expression to lower case.
 //
 // Lower is the Golang equivalent of lower: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Lower(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("lower", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("lower", col))
 }
 
 // Ascii - Computes the numeric value of the first character of the string column.
 //
 // Ascii is the Golang equivalent of ascii: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Ascii(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("ascii", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("ascii", col))
 }
 
 // Base64 - Computes the BASE64 encoding of a binary column and returns it as a string column.
 //
 // Base64 is the Golang equivalent of base64: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Base64(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("base64", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("base64", col))
 }
 
 // Unbase64 - Decodes a BASE64 encoded string column and returns it as a binary column.
 //
 // Unbase64 is the Golang equivalent of unbase64: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Unbase64(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("unbase64", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("unbase64", col))
 }
 
 // Ltrim - Trim the spaces from left end for the specified string value.
 //
 // Ltrim is the Golang equivalent of ltrim: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Ltrim(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("ltrim", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("ltrim", col))
 }
 
 // Rtrim - Trim the spaces from right end for the specified string value.
 //
 // Rtrim is the Golang equivalent of rtrim: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Rtrim(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("rtrim", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("rtrim", col))
 }
 
 // Trim - Trim the spaces from both ends for the specified string column.
 //
 // Trim is the Golang equivalent of trim: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Trim(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("trim", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("trim", col))
 }
 
 // ConcatWs - Concatenates multiple input string columns together into a single string column,
@@ -1618,11 +1617,11 @@ func Trim(col column.Column) column.Column {
 //
 // ConcatWs is the Golang equivalent of concat_ws: (sep: str, *cols: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func ConcatWs(sep string, cols ...column.Column) column.Column {
-    lit_sep := StringLit(sep)
-    vals := make([]column.Column, 0)
-    vals = append(vals, lit_sep)
-    vals = append(vals, cols...)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("concat_ws", vals...))
+	lit_sep := StringLit(sep)
+	vals := make([]column.Column, 0)
+	vals = append(vals, lit_sep)
+	vals = append(vals, cols...)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("concat_ws", vals...))
 }
 
 // Decode - Computes the first argument into a string from a binary using the provided character set
@@ -1630,8 +1629,8 @@ func ConcatWs(sep string, cols ...column.Column) column.Column {
 //
 // Decode is the Golang equivalent of decode: (col: 'ColumnOrName', charset: str) -> pyspark.sql.connect.column.Column
 func Decode(col column.Column, charset string) column.Column {
-    lit_charset := StringLit(charset)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("decode", col, lit_charset))
+	lit_charset := StringLit(charset)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("decode", col, lit_charset))
 }
 
 // Encode - Computes the first argument into a binary from a string using the provided character set
@@ -1639,8 +1638,8 @@ func Decode(col column.Column, charset string) column.Column {
 //
 // Encode is the Golang equivalent of encode: (col: 'ColumnOrName', charset: str) -> pyspark.sql.connect.column.Column
 func Encode(col column.Column, charset string) column.Column {
-    lit_charset := StringLit(charset)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("encode", col, lit_charset))
+	lit_charset := StringLit(charset)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("encode", col, lit_charset))
 }
 
 // FormatNumber - Formats the number X to a format like '#,--#,--#.--', rounded to d decimal places
@@ -1648,19 +1647,19 @@ func Encode(col column.Column, charset string) column.Column {
 //
 // FormatNumber is the Golang equivalent of format_number: (col: 'ColumnOrName', d: int) -> pyspark.sql.connect.column.Column
 func FormatNumber(col column.Column, d int64) column.Column {
-    lit_d := Int64Lit(d)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("format_number", col, lit_d))
+	lit_d := Int64Lit(d)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("format_number", col, lit_d))
 }
 
 // FormatString - Formats the arguments in printf-style and returns the result as a string column.
 //
 // FormatString is the Golang equivalent of format_string: (format: str, *cols: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func FormatString(format string, cols ...column.Column) column.Column {
-    lit_format := StringLit(format)
-    vals := make([]column.Column, 0)
-    vals = append(vals, lit_format)
-    vals = append(vals, cols...)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("format_string", vals...))
+	lit_format := StringLit(format)
+	vals := make([]column.Column, 0)
+	vals = append(vals, lit_format)
+	vals = append(vals, cols...)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("format_string", vals...))
 }
 
 // Instr - Locate the position of the first occurrence of substr column in the given string.
@@ -1668,8 +1667,8 @@ func FormatString(format string, cols ...column.Column) column.Column {
 //
 // Instr is the Golang equivalent of instr: (str: 'ColumnOrName', substr: str) -> pyspark.sql.connect.column.Column
 func Instr(str column.Column, substr string) column.Column {
-    lit_substr := StringLit(substr)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("instr", str, lit_substr))
+	lit_substr := StringLit(substr)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("instr", str, lit_substr))
 }
 
 // Overlay - Overlay the specified portion of `src` with `replace`,
@@ -1677,7 +1676,7 @@ func Instr(str column.Column, substr string) column.Column {
 //
 // Overlay is the Golang equivalent of overlay: (src: 'ColumnOrName', replace: 'ColumnOrName', pos: Union[ForwardRef('ColumnOrName'), int], len: Union[ForwardRef('ColumnOrName'), int] = -1) -> pyspark.sql.connect.column.Column
 func Overlay(src column.Column, replace column.Column, pos column.Column, len column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("overlay", src, replace, pos, len))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("overlay", src, replace, pos, len))
 }
 
 // Sentences - Splits a string into arrays of sentences, where each sentence is an array of words.
@@ -1685,7 +1684,7 @@ func Overlay(src column.Column, replace column.Column, pos column.Column, len co
 //
 // Sentences is the Golang equivalent of sentences: (string: 'ColumnOrName', language: Optional[ForwardRef('ColumnOrName')] = None, country: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
 func Sentences(string column.Column, language column.Column, country column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sentences", string, language, country))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sentences", string, language, country))
 }
 
 // Substring - Substring starts at `pos` and is of length `len` when str is String type or
@@ -1694,9 +1693,9 @@ func Sentences(string column.Column, language column.Column, country column.Colu
 //
 // Substring is the Golang equivalent of substring: (str: 'ColumnOrName', pos: int, len: int) -> pyspark.sql.connect.column.Column
 func Substring(str column.Column, pos int64, len int64) column.Column {
-    lit_pos := Int64Lit(pos)
-    lit_len := Int64Lit(len)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("substring", str, lit_pos, lit_len))
+	lit_pos := Int64Lit(pos)
+	lit_len := Int64Lit(len)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("substring", str, lit_pos, lit_len))
 }
 
 // SubstringIndex - Returns the substring from string str before count occurrences of the delimiter delim.
@@ -1706,82 +1705,82 @@ func Substring(str column.Column, pos int64, len int64) column.Column {
 //
 // SubstringIndex is the Golang equivalent of substring_index: (str: 'ColumnOrName', delim: str, count: int) -> pyspark.sql.connect.column.Column
 func SubstringIndex(str column.Column, delim string, count int64) column.Column {
-    lit_delim := StringLit(delim)
-    lit_count := Int64Lit(count)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("substring_index", str, lit_delim, lit_count))
+	lit_delim := StringLit(delim)
+	lit_count := Int64Lit(count)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("substring_index", str, lit_delim, lit_count))
 }
 
 // Levenshtein - Computes the Levenshtein distance of the two given strings.
 //
 // Levenshtein is the Golang equivalent of levenshtein: (left: 'ColumnOrName', right: 'ColumnOrName', threshold: Optional[int] = None) -> pyspark.sql.connect.column.Column
 func Levenshtein(left column.Column, right column.Column, threshold int64) column.Column {
-    lit_threshold := Int64Lit(threshold)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("levenshtein", left, right, lit_threshold))
+	lit_threshold := Int64Lit(threshold)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("levenshtein", left, right, lit_threshold))
 }
 
 // Locate - Locate the position of the first occurrence of substr in a string column, after position pos.
 //
 // Locate is the Golang equivalent of locate: (substr: str, str: 'ColumnOrName', pos: int = 1) -> pyspark.sql.connect.column.Column
 func Locate(substr string, str column.Column, pos int64) column.Column {
-    lit_substr := StringLit(substr)
-    lit_pos := Int64Lit(pos)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("locate", lit_substr, str, lit_pos))
+	lit_substr := StringLit(substr)
+	lit_pos := Int64Lit(pos)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("locate", lit_substr, str, lit_pos))
 }
 
 // Lpad - Left-pad the string column to width `len` with `pad`.
 //
 // Lpad is the Golang equivalent of lpad: (col: 'ColumnOrName', len: int, pad: str) -> pyspark.sql.connect.column.Column
 func Lpad(col column.Column, len int64, pad string) column.Column {
-    lit_len := Int64Lit(len)
-    lit_pad := StringLit(pad)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("lpad", col, lit_len, lit_pad))
+	lit_len := Int64Lit(len)
+	lit_pad := StringLit(pad)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("lpad", col, lit_len, lit_pad))
 }
 
 // Rpad - Right-pad the string column to width `len` with `pad`.
 //
 // Rpad is the Golang equivalent of rpad: (col: 'ColumnOrName', len: int, pad: str) -> pyspark.sql.connect.column.Column
 func Rpad(col column.Column, len int64, pad string) column.Column {
-    lit_len := Int64Lit(len)
-    lit_pad := StringLit(pad)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("rpad", col, lit_len, lit_pad))
+	lit_len := Int64Lit(len)
+	lit_pad := StringLit(pad)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("rpad", col, lit_len, lit_pad))
 }
 
 // Repeat - Repeats a string column n times, and returns it as a new string column.
 //
 // Repeat is the Golang equivalent of repeat: (col: 'ColumnOrName', n: int) -> pyspark.sql.connect.column.Column
 func Repeat(col column.Column, n int64) column.Column {
-    lit_n := Int64Lit(n)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("repeat", col, lit_n))
+	lit_n := Int64Lit(n)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("repeat", col, lit_n))
 }
 
 // Split - Splits str around matches of the given pattern.
 //
 // Split is the Golang equivalent of split: (str: 'ColumnOrName', pattern: str, limit: int = -1) -> pyspark.sql.connect.column.Column
 func Split(str column.Column, pattern string, limit int64) column.Column {
-    lit_pattern := StringLit(pattern)
-    lit_limit := Int64Lit(limit)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("split", str, lit_pattern, lit_limit))
+	lit_pattern := StringLit(pattern)
+	lit_limit := Int64Lit(limit)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("split", str, lit_pattern, lit_limit))
 }
 
 // Rlike - Returns true if `str` matches the Java regex `regexp`, or false otherwise.
 //
 // Rlike is the Golang equivalent of rlike: (str: 'ColumnOrName', regexp: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Rlike(str column.Column, regexp column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("rlike", str, regexp))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("rlike", str, regexp))
 }
 
 // Regexp - Returns true if `str` matches the Java regex `regexp`, or false otherwise.
 //
 // Regexp is the Golang equivalent of regexp: (str: 'ColumnOrName', regexp: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Regexp(str column.Column, regexp column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regexp", str, regexp))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regexp", str, regexp))
 }
 
 // RegexpLike - Returns true if `str` matches the Java regex `regexp`, or false otherwise.
 //
 // RegexpLike is the Golang equivalent of regexp_like: (str: 'ColumnOrName', regexp: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func RegexpLike(str column.Column, regexp column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regexp_like", str, regexp))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regexp_like", str, regexp))
 }
 
 // RegexpCount - Returns a count of the number of times that the Java regex pattern `regexp` is matched
@@ -1789,7 +1788,7 @@ func RegexpLike(str column.Column, regexp column.Column) column.Column {
 //
 // RegexpCount is the Golang equivalent of regexp_count: (str: 'ColumnOrName', regexp: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func RegexpCount(str column.Column, regexp column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regexp_count", str, regexp))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regexp_count", str, regexp))
 }
 
 // RegexpExtract - Extract a specific group matched by the Java regex `regexp`, from the specified string column.
@@ -1797,9 +1796,9 @@ func RegexpCount(str column.Column, regexp column.Column) column.Column {
 //
 // RegexpExtract is the Golang equivalent of regexp_extract: (str: 'ColumnOrName', pattern: str, idx: int) -> pyspark.sql.connect.column.Column
 func RegexpExtract(str column.Column, pattern string, idx int64) column.Column {
-    lit_pattern := StringLit(pattern)
-    lit_idx := Int64Lit(idx)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regexp_extract", str, lit_pattern, lit_idx))
+	lit_pattern := StringLit(pattern)
+	lit_idx := Int64Lit(idx)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regexp_extract", str, lit_pattern, lit_idx))
 }
 
 // TODO: regexp_extract_all: (str: 'ColumnOrName', regexp: 'ColumnOrName', idx: Union[int, pyspark.sql.connect.column.Column, NoneType] = None) -> pyspark.sql.connect.column.Column
@@ -1811,7 +1810,7 @@ func RegexpExtract(str column.Column, pattern string, idx int64) column.Column {
 //
 // RegexpSubstr is the Golang equivalent of regexp_substr: (str: 'ColumnOrName', regexp: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func RegexpSubstr(str column.Column, regexp column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regexp_substr", str, regexp))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("regexp_substr", str, regexp))
 }
 
 // TODO: regexp_instr: (str: 'ColumnOrName', regexp: 'ColumnOrName', idx: Union[int, pyspark.sql.connect.column.Column, NoneType] = None) -> pyspark.sql.connect.column.Column
@@ -1820,14 +1819,14 @@ func RegexpSubstr(str column.Column, regexp column.Column) column.Column {
 //
 // Initcap is the Golang equivalent of initcap: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Initcap(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("initcap", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("initcap", col))
 }
 
 // Soundex - Returns the SoundEx encoding for a string
 //
 // Soundex is the Golang equivalent of soundex: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Soundex(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("soundex", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("soundex", col))
 }
 
 // Length - Computes the character length of string data or number of bytes of binary data.
@@ -1836,21 +1835,21 @@ func Soundex(col column.Column) column.Column {
 //
 // Length is the Golang equivalent of length: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Length(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("length", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("length", col))
 }
 
 // OctetLength - Calculates the byte length for the specified string column.
 //
 // OctetLength is the Golang equivalent of octet_length: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func OctetLength(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("octet_length", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("octet_length", col))
 }
 
 // BitLength - Calculates the bit length for the specified string column.
 //
 // BitLength is the Golang equivalent of bit_length: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func BitLength(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bit_length", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bit_length", col))
 }
 
 // Translate - A function translate any character in the `srcCol` by a character in `matching`.
@@ -1860,9 +1859,9 @@ func BitLength(col column.Column) column.Column {
 //
 // Translate is the Golang equivalent of translate: (srcCol: 'ColumnOrName', matching: str, replace: str) -> pyspark.sql.connect.column.Column
 func Translate(srcCol column.Column, matching string, replace string) column.Column {
-    lit_matching := StringLit(matching)
-    lit_replace := StringLit(replace)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("translate", srcCol, lit_matching, lit_replace))
+	lit_matching := StringLit(matching)
+	lit_replace := StringLit(replace)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("translate", srcCol, lit_matching, lit_replace))
 }
 
 // ToBinary - Converts the input `col` to a binary value based on the supplied `format`.
@@ -1873,7 +1872,7 @@ func Translate(srcCol column.Column, matching string, replace string) column.Col
 //
 // ToBinary is the Golang equivalent of to_binary: (col: 'ColumnOrName', format: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
 func ToBinary(col column.Column, format column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("to_binary", col, format))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("to_binary", col, format))
 }
 
 // ToChar - Convert `col` to a string based on the `format`.
@@ -1897,7 +1896,7 @@ func ToBinary(col column.Column, format column.Column) column.Column {
 //
 // ToChar is the Golang equivalent of to_char: (col: 'ColumnOrName', format: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func ToChar(col column.Column, format column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("to_char", col, format))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("to_char", col, format))
 }
 
 // ToVarchar - Convert `col` to a string based on the `format`.
@@ -1921,7 +1920,7 @@ func ToChar(col column.Column, format column.Column) column.Column {
 //
 // ToVarchar is the Golang equivalent of to_varchar: (col: 'ColumnOrName', format: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func ToVarchar(col column.Column, format column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("to_varchar", col, format))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("to_varchar", col, format))
 }
 
 // ToNumber - Convert string 'col' to a number based on the string format 'format'.
@@ -1946,14 +1945,14 @@ func ToVarchar(col column.Column, format column.Column) column.Column {
 //
 // ToNumber is the Golang equivalent of to_number: (col: 'ColumnOrName', format: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func ToNumber(col column.Column, format column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("to_number", col, format))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("to_number", col, format))
 }
 
 // Replace - Replaces all occurrences of `search` with `replace`.
 //
 // Replace is the Golang equivalent of replace: (src: 'ColumnOrName', search: 'ColumnOrName', replace: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
 func Replace(src column.Column, search column.Column, replace column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("replace", src, search, replace))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("replace", src, search, replace))
 }
 
 // SplitPart - Splits `str` by delimiter and return requested part of the split (1-based).
@@ -1964,7 +1963,7 @@ func Replace(src column.Column, search column.Column, replace column.Column) col
 //
 // SplitPart is the Golang equivalent of split_part: (src: 'ColumnOrName', delimiter: 'ColumnOrName', partNum: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func SplitPart(src column.Column, delimiter column.Column, partNum column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("split_part", src, delimiter, partNum))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("split_part", src, delimiter, partNum))
 }
 
 // Substr - Returns the substring of `str` that starts at `pos` and is of length `len`,
@@ -1972,24 +1971,24 @@ func SplitPart(src column.Column, delimiter column.Column, partNum column.Column
 //
 // Substr is the Golang equivalent of substr: (str: 'ColumnOrName', pos: 'ColumnOrName', len: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
 func Substr(str column.Column, pos column.Column, len column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("substr", str, pos, len))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("substr", str, pos, len))
 }
 
 // ParseUrl - Extracts a part from a URL.
 //
 // ParseUrl is the Golang equivalent of parse_url: (url: 'ColumnOrName', partToExtract: 'ColumnOrName', key: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
 func ParseUrl(url column.Column, partToExtract column.Column, key column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("parse_url", url, partToExtract, key))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("parse_url", url, partToExtract, key))
 }
 
 // Printf - Formats the arguments in printf-style and returns the result as a string column.
 //
 // Printf is the Golang equivalent of printf: (format: 'ColumnOrName', *cols: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Printf(format column.Column, cols ...column.Column) column.Column {
-    vals := make([]column.Column, 0)
-    vals = append(vals, format)
-    vals = append(vals, cols...)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("printf", vals...))
+	vals := make([]column.Column, 0)
+	vals = append(vals, format)
+	vals = append(vals, cols...)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("printf", vals...))
 }
 
 // UrlDecode - Decodes a `str` in 'application/x-www-form-urlencoded' format
@@ -1997,7 +1996,7 @@ func Printf(format column.Column, cols ...column.Column) column.Column {
 //
 // UrlDecode is the Golang equivalent of url_decode: (str: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func UrlDecode(str column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("url_decode", str))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("url_decode", str))
 }
 
 // UrlEncode - Translates a string into 'application/x-www-form-urlencoded' format
@@ -2005,7 +2004,7 @@ func UrlDecode(str column.Column) column.Column {
 //
 // UrlEncode is the Golang equivalent of url_encode: (str: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func UrlEncode(str column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("url_encode", str))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("url_encode", str))
 }
 
 // Position - Returns the position of the first occurrence of `substr` in `str` after position `start`.
@@ -2013,7 +2012,7 @@ func UrlEncode(str column.Column) column.Column {
 //
 // Position is the Golang equivalent of position: (substr: 'ColumnOrName', str: 'ColumnOrName', start: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
 func Position(substr column.Column, str column.Column, start column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("position", substr, str, start))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("position", substr, str, start))
 }
 
 // Endswith - Returns a boolean. The value is True if str ends with suffix.
@@ -2022,7 +2021,7 @@ func Position(substr column.Column, str column.Column, start column.Column) colu
 //
 // Endswith is the Golang equivalent of endswith: (str: 'ColumnOrName', suffix: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Endswith(str column.Column, suffix column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("endswith", str, suffix))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("endswith", str, suffix))
 }
 
 // Startswith - Returns a boolean. The value is True if str starts with prefix.
@@ -2031,7 +2030,7 @@ func Endswith(str column.Column, suffix column.Column) column.Column {
 //
 // Startswith is the Golang equivalent of startswith: (str: 'ColumnOrName', prefix: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Startswith(str column.Column, prefix column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("startswith", str, prefix))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("startswith", str, prefix))
 }
 
 // Char - Returns the ASCII character having the binary equivalent to `col`. If col is larger than 256 the
@@ -2039,7 +2038,7 @@ func Startswith(str column.Column, prefix column.Column) column.Column {
 //
 // Char is the Golang equivalent of char: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Char(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("char", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("char", col))
 }
 
 // TryToBinary - This is a special version of `to_binary` that performs the same operation, but returns a NULL
@@ -2047,7 +2046,7 @@ func Char(col column.Column) column.Column {
 //
 // TryToBinary is the Golang equivalent of try_to_binary: (col: 'ColumnOrName', format: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
 func TryToBinary(col column.Column, format column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_to_binary", col, format))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_to_binary", col, format))
 }
 
 // TryToNumber - Convert string 'col' to a number based on the string format `format`. Returns NULL if the
@@ -2056,14 +2055,14 @@ func TryToBinary(col column.Column, format column.Column) column.Column {
 //
 // TryToNumber is the Golang equivalent of try_to_number: (col: 'ColumnOrName', format: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func TryToNumber(col column.Column, format column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_to_number", col, format))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_to_number", col, format))
 }
 
 // Btrim - Remove the leading and trailing `trim` characters from `str`.
 //
 // Btrim is the Golang equivalent of btrim: (str: 'ColumnOrName', trim: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
 func Btrim(str column.Column, trim column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("btrim", str, trim))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("btrim", str, trim))
 }
 
 // CharLength - Returns the character length of string data or number of bytes of binary data.
@@ -2072,7 +2071,7 @@ func Btrim(str column.Column, trim column.Column) column.Column {
 //
 // CharLength is the Golang equivalent of char_length: (str: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func CharLength(str column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("char_length", str))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("char_length", str))
 }
 
 // CharacterLength - Returns the character length of string data or number of bytes of binary data.
@@ -2081,7 +2080,7 @@ func CharLength(str column.Column) column.Column {
 //
 // CharacterLength is the Golang equivalent of character_length: (str: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func CharacterLength(str column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("character_length", str))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("character_length", str))
 }
 
 // Contains - Returns a boolean. The value is True if right is found inside left.
@@ -2090,7 +2089,7 @@ func CharacterLength(str column.Column) column.Column {
 //
 // Contains is the Golang equivalent of contains: (left: 'ColumnOrName', right: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Contains(left column.Column, right column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("contains", left, right))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("contains", left, right))
 }
 
 // Elt - Returns the `n`-th input, e.g., returns `input2` when `n` is 2.
@@ -2100,9 +2099,9 @@ func Contains(left column.Column, right column.Column) column.Column {
 //
 // Elt is the Golang equivalent of elt: (*inputs: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Elt(inputs ...column.Column) column.Column {
-    vals := make([]column.Column, 0)
-    vals = append(vals, inputs...)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("elt", vals...))
+	vals := make([]column.Column, 0)
+	vals = append(vals, inputs...)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("elt", vals...))
 }
 
 // FindInSet - Returns the index (1-based) of the given string (`str`) in the comma-delimited
@@ -2111,7 +2110,7 @@ func Elt(inputs ...column.Column) column.Column {
 //
 // FindInSet is the Golang equivalent of find_in_set: (str: 'ColumnOrName', str_array: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func FindInSet(str column.Column, str_array column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("find_in_set", str, str_array))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("find_in_set", str, str_array))
 }
 
 // TODO: like: (str: 'ColumnOrName', pattern: 'ColumnOrName', escapeChar: Optional[ForwardRef('Column')] = None) -> pyspark.sql.connect.column.Column
@@ -2122,14 +2121,14 @@ func FindInSet(str column.Column, str_array column.Column) column.Column {
 //
 // Lcase is the Golang equivalent of lcase: (str: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Lcase(str column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("lcase", str))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("lcase", str))
 }
 
 // Ucase - Returns `str` with all characters changed to uppercase.
 //
 // Ucase is the Golang equivalent of ucase: (str: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Ucase(str column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("ucase", str))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("ucase", str))
 }
 
 // Left - Returns the leftmost `len`(`len` can be string type) characters from the string `str`,
@@ -2137,7 +2136,7 @@ func Ucase(str column.Column) column.Column {
 //
 // Left is the Golang equivalent of left: (str: 'ColumnOrName', len: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Left(str column.Column, len column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("left", str, len))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("left", str, len))
 }
 
 // Right - Returns the rightmost `len`(`len` can be string type) characters from the string `str`,
@@ -2145,15 +2144,17 @@ func Left(str column.Column, len column.Column) column.Column {
 //
 // Right is the Golang equivalent of right: (str: 'ColumnOrName', len: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Right(str column.Column, len column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("right", str, len))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("right", str, len))
 }
 
 // Mask - Masks the given string value. This can be useful for creating copies of tables with sensitive
 // information removed.
 //
 // Mask is the Golang equivalent of mask: (col: 'ColumnOrName', upperChar: Optional[ForwardRef('ColumnOrName')] = None, lowerChar: Optional[ForwardRef('ColumnOrName')] = None, digitChar: Optional[ForwardRef('ColumnOrName')] = None, otherChar: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
-func Mask(col column.Column, upperChar column.Column, lowerChar column.Column, digitChar column.Column, otherChar column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("mask", col, upperChar, lowerChar, digitChar, otherChar))
+func Mask(col column.Column, upperChar column.Column, lowerChar column.Column,
+	digitChar column.Column, otherChar column.Column,
+) column.Column {
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("mask", col, upperChar, lowerChar, digitChar, otherChar))
 }
 
 // Curdate - Returns the current date at the start of query evaluation as a :class:`DateType` column.
@@ -2161,7 +2162,7 @@ func Mask(col column.Column, upperChar column.Column, lowerChar column.Column, d
 //
 // Curdate is the Golang equivalent of curdate: () -> pyspark.sql.connect.column.Column
 func Curdate() column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("curdate", ))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("curdate"))
 }
 
 // CurrentDate - Returns the current date at the start of query evaluation as a :class:`DateType` column.
@@ -2169,7 +2170,7 @@ func Curdate() column.Column {
 //
 // CurrentDate is the Golang equivalent of current_date: () -> pyspark.sql.connect.column.Column
 func CurrentDate() column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("current_date", ))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("current_date"))
 }
 
 // CurrentTimestamp - Returns the current timestamp at the start of query evaluation as a :class:`TimestampType`
@@ -2177,21 +2178,21 @@ func CurrentDate() column.Column {
 //
 // CurrentTimestamp is the Golang equivalent of current_timestamp: () -> pyspark.sql.connect.column.Column
 func CurrentTimestamp() column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("current_timestamp", ))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("current_timestamp"))
 }
 
 // Now - Returns the current timestamp at the start of query evaluation.
 //
 // Now is the Golang equivalent of now: () -> pyspark.sql.connect.column.Column
 func Now() column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("now", ))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("now"))
 }
 
 // CurrentTimezone - Returns the current session local timezone.
 //
 // CurrentTimezone is the Golang equivalent of current_timezone: () -> pyspark.sql.connect.column.Column
 func CurrentTimezone() column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("current_timezone", ))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("current_timezone"))
 }
 
 // Localtimestamp - Returns the current timestamp without time zone at the start of query evaluation
@@ -2200,40 +2201,40 @@ func CurrentTimezone() column.Column {
 //
 // Localtimestamp is the Golang equivalent of localtimestamp: () -> pyspark.sql.connect.column.Column
 func Localtimestamp() column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("localtimestamp", ))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("localtimestamp"))
 }
 
 // DateFormat - Converts a date/timestamp/string to a value of string in the format specified by the date
 // format given by the second argument.
-// 
+//
 // A pattern could be for instance `dd.MM.yyyy` and could return a string like '18.03.1993'. All
 // pattern letters of `datetime pattern`_. can be used.
 //
 // DateFormat is the Golang equivalent of date_format: (date: 'ColumnOrName', format: str) -> pyspark.sql.connect.column.Column
 func DateFormat(date column.Column, format string) column.Column {
-    lit_format := StringLit(format)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("date_format", date, lit_format))
+	lit_format := StringLit(format)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("date_format", date, lit_format))
 }
 
 // Year - Extract the year of a given date/timestamp as integer.
 //
 // Year is the Golang equivalent of year: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Year(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("year", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("year", col))
 }
 
 // Quarter - Extract the quarter of a given date/timestamp as integer.
 //
 // Quarter is the Golang equivalent of quarter: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Quarter(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("quarter", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("quarter", col))
 }
 
 // Month - Extract the month of a given date/timestamp as integer.
 //
 // Month is the Golang equivalent of month: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Month(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("month", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("month", col))
 }
 
 // Dayofweek - Extract the day of the week of a given date/timestamp as integer.
@@ -2241,49 +2242,49 @@ func Month(col column.Column) column.Column {
 //
 // Dayofweek is the Golang equivalent of dayofweek: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Dayofweek(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("dayofweek", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("dayofweek", col))
 }
 
 // Dayofmonth - Extract the day of the month of a given date/timestamp as integer.
 //
 // Dayofmonth is the Golang equivalent of dayofmonth: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Dayofmonth(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("dayofmonth", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("dayofmonth", col))
 }
 
 // Day - Extract the day of the month of a given date/timestamp as integer.
 //
 // Day is the Golang equivalent of day: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Day(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("day", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("day", col))
 }
 
 // Dayofyear - Extract the day of the year of a given date/timestamp as integer.
 //
 // Dayofyear is the Golang equivalent of dayofyear: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Dayofyear(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("dayofyear", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("dayofyear", col))
 }
 
 // Hour - Extract the hours of a given timestamp as integer.
 //
 // Hour is the Golang equivalent of hour: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Hour(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("hour", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("hour", col))
 }
 
 // Minute - Extract the minutes of a given timestamp as integer.
 //
 // Minute is the Golang equivalent of minute: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Minute(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("minute", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("minute", col))
 }
 
 // Second - Extract the seconds of a given date as integer.
 //
 // Second is the Golang equivalent of second: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Second(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("second", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("second", col))
 }
 
 // Weekofyear - Extract the week number of a given date as integer.
@@ -2292,38 +2293,38 @@ func Second(col column.Column) column.Column {
 //
 // Weekofyear is the Golang equivalent of weekofyear: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Weekofyear(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("weekofyear", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("weekofyear", col))
 }
 
 // Weekday - Returns the day of the week for date/timestamp (0 = Monday, 1 = Tuesday, ..., 6 = Sunday).
 //
 // Weekday is the Golang equivalent of weekday: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Weekday(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("weekday", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("weekday", col))
 }
 
 // Extract - Extracts a part of the date/timestamp or interval source.
 //
 // Extract is the Golang equivalent of extract: (field: 'ColumnOrName', source: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Extract(field column.Column, source column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("extract", field, source))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("extract", field, source))
 }
 
 // DatePart is the Golang equivalent of date_part: (field: 'ColumnOrName', source: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func DatePart(field column.Column, source column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("date_part", field, source))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("date_part", field, source))
 }
 
 // Datepart is the Golang equivalent of datepart: (field: 'ColumnOrName', source: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Datepart(field column.Column, source column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("datepart", field, source))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("datepart", field, source))
 }
 
 // MakeDate - Returns a column with a date built from the year, month and day columns.
 //
 // MakeDate is the Golang equivalent of make_date: (year: 'ColumnOrName', month: 'ColumnOrName', day: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func MakeDate(year column.Column, month column.Column, day column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("make_date", year, month, day))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("make_date", year, month, day))
 }
 
 // DateAdd - Returns the date that is `days` days after `start`. If `days` is a negative value
@@ -2331,7 +2332,7 @@ func MakeDate(year column.Column, month column.Column, day column.Column) column
 //
 // DateAdd is the Golang equivalent of date_add: (start: 'ColumnOrName', days: Union[ForwardRef('ColumnOrName'), int]) -> pyspark.sql.connect.column.Column
 func DateAdd(start column.Column, days column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("date_add", start, days))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("date_add", start, days))
 }
 
 // Dateadd - Returns the date that is `days` days after `start`. If `days` is a negative value
@@ -2339,7 +2340,7 @@ func DateAdd(start column.Column, days column.Column) column.Column {
 //
 // Dateadd is the Golang equivalent of dateadd: (start: 'ColumnOrName', days: Union[ForwardRef('ColumnOrName'), int]) -> pyspark.sql.connect.column.Column
 func Dateadd(start column.Column, days column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("dateadd", start, days))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("dateadd", start, days))
 }
 
 // DateSub - Returns the date that is `days` days before `start`. If `days` is a negative value
@@ -2347,28 +2348,28 @@ func Dateadd(start column.Column, days column.Column) column.Column {
 //
 // DateSub is the Golang equivalent of date_sub: (start: 'ColumnOrName', days: Union[ForwardRef('ColumnOrName'), int]) -> pyspark.sql.connect.column.Column
 func DateSub(start column.Column, days column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("date_sub", start, days))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("date_sub", start, days))
 }
 
 // Datediff - Returns the number of days from `start` to `end`.
 //
 // Datediff is the Golang equivalent of datediff: (end: 'ColumnOrName', start: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Datediff(end column.Column, start column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("datediff", end, start))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("datediff", end, start))
 }
 
 // DateDiff - Returns the number of days from `start` to `end`.
 //
 // DateDiff is the Golang equivalent of date_diff: (end: 'ColumnOrName', start: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func DateDiff(end column.Column, start column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("date_diff", end, start))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("date_diff", end, start))
 }
 
 // DateFromUnixDate - Create date from the number of `days` since 1970-01-01.
 //
 // DateFromUnixDate is the Golang equivalent of date_from_unix_date: (days: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func DateFromUnixDate(days column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("date_from_unix_date", days))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("date_from_unix_date", days))
 }
 
 // AddMonths - Returns the date that is `months` months after `start`. If `months` is a negative value
@@ -2376,7 +2377,7 @@ func DateFromUnixDate(days column.Column) column.Column {
 //
 // AddMonths is the Golang equivalent of add_months: (start: 'ColumnOrName', months: Union[ForwardRef('ColumnOrName'), int]) -> pyspark.sql.connect.column.Column
 func AddMonths(start column.Column, months column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("add_months", start, months))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("add_months", start, months))
 }
 
 // TODO: months_between: (date1: 'ColumnOrName', date2: 'ColumnOrName', roundOff: bool = True) -> pyspark.sql.connect.column.Column
@@ -2384,26 +2385,26 @@ func AddMonths(start column.Column, months column.Column) column.Column {
 // ToDate - Converts a :class:`~pyspark.sql.Column` into :class:`pyspark.sql.types.DateType`
 // using the optionally specified format. Specify formats according to `datetime pattern`_.
 // By default, it follows casting rules to :class:`pyspark.sql.types.DateType` if the format
-// is omitted. Equivalent to ``col.cast("date")``.
+// is omitted. Equivalent to “col.cast("date")“.
 //
 // ToDate is the Golang equivalent of to_date: (col: 'ColumnOrName', format: Optional[str] = None) -> pyspark.sql.connect.column.Column
 func ToDate(col column.Column, format string) column.Column {
-    lit_format := StringLit(format)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("to_date", col, lit_format))
+	lit_format := StringLit(format)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("to_date", col, lit_format))
 }
 
 // UnixDate - Returns the number of days since 1970-01-01.
 //
 // UnixDate is the Golang equivalent of unix_date: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func UnixDate(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("unix_date", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("unix_date", col))
 }
 
 // UnixMicros - Returns the number of microseconds since 1970-01-01 00:00:00 UTC.
 //
 // UnixMicros is the Golang equivalent of unix_micros: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func UnixMicros(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("unix_micros", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("unix_micros", col))
 }
 
 // UnixMillis - Returns the number of milliseconds since 1970-01-01 00:00:00 UTC.
@@ -2411,7 +2412,7 @@ func UnixMicros(col column.Column) column.Column {
 //
 // UnixMillis is the Golang equivalent of unix_millis: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func UnixMillis(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("unix_millis", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("unix_millis", col))
 }
 
 // UnixSeconds - Returns the number of seconds since 1970-01-01 00:00:00 UTC.
@@ -2419,18 +2420,18 @@ func UnixMillis(col column.Column) column.Column {
 //
 // UnixSeconds is the Golang equivalent of unix_seconds: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func UnixSeconds(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("unix_seconds", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("unix_seconds", col))
 }
 
 // ToTimestamp - Converts a :class:`~pyspark.sql.Column` into :class:`pyspark.sql.types.TimestampType`
 // using the optionally specified format. Specify formats according to `datetime pattern`_.
 // By default, it follows casting rules to :class:`pyspark.sql.types.TimestampType` if the format
-// is omitted. Equivalent to ``col.cast("timestamp")``.
+// is omitted. Equivalent to “col.cast("timestamp")“.
 //
 // ToTimestamp is the Golang equivalent of to_timestamp: (col: 'ColumnOrName', format: Optional[str] = None) -> pyspark.sql.connect.column.Column
 func ToTimestamp(col column.Column, format string) column.Column {
-    lit_format := StringLit(format)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("to_timestamp", col, lit_format))
+	lit_format := StringLit(format)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("to_timestamp", col, lit_format))
 }
 
 // TryToTimestamp - Parses the `col` with the `format` to a timestamp. The function always
@@ -2439,21 +2440,21 @@ func ToTimestamp(col column.Column, format string) column.Column {
 //
 // TryToTimestamp is the Golang equivalent of try_to_timestamp: (col: 'ColumnOrName', format: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
 func TryToTimestamp(col column.Column, format column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_to_timestamp", col, format))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_to_timestamp", col, format))
 }
 
 // Xpath - Returns a string array of values within the nodes of xml that match the XPath expression.
 //
 // Xpath is the Golang equivalent of xpath: (xml: 'ColumnOrName', path: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Xpath(xml column.Column, path column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("xpath", xml, path))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("xpath", xml, path))
 }
 
 // XpathBoolean - Returns true if the XPath expression evaluates to true, or if a matching node is found.
 //
 // XpathBoolean is the Golang equivalent of xpath_boolean: (xml: 'ColumnOrName', path: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func XpathBoolean(xml column.Column, path column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("xpath_boolean", xml, path))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("xpath_boolean", xml, path))
 }
 
 // XpathDouble - Returns a double value, the value zero if no match is found,
@@ -2461,7 +2462,7 @@ func XpathBoolean(xml column.Column, path column.Column) column.Column {
 //
 // XpathDouble is the Golang equivalent of xpath_double: (xml: 'ColumnOrName', path: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func XpathDouble(xml column.Column, path column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("xpath_double", xml, path))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("xpath_double", xml, path))
 }
 
 // XpathNumber - Returns a double value, the value zero if no match is found,
@@ -2469,7 +2470,7 @@ func XpathDouble(xml column.Column, path column.Column) column.Column {
 //
 // XpathNumber is the Golang equivalent of xpath_number: (xml: 'ColumnOrName', path: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func XpathNumber(xml column.Column, path column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("xpath_number", xml, path))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("xpath_number", xml, path))
 }
 
 // XpathFloat - Returns a float value, the value zero if no match is found,
@@ -2477,7 +2478,7 @@ func XpathNumber(xml column.Column, path column.Column) column.Column {
 //
 // XpathFloat is the Golang equivalent of xpath_float: (xml: 'ColumnOrName', path: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func XpathFloat(xml column.Column, path column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("xpath_float", xml, path))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("xpath_float", xml, path))
 }
 
 // XpathInt - Returns an integer value, or the value zero if no match is found,
@@ -2485,7 +2486,7 @@ func XpathFloat(xml column.Column, path column.Column) column.Column {
 //
 // XpathInt is the Golang equivalent of xpath_int: (xml: 'ColumnOrName', path: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func XpathInt(xml column.Column, path column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("xpath_int", xml, path))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("xpath_int", xml, path))
 }
 
 // XpathLong - Returns a long integer value, or the value zero if no match is found,
@@ -2493,7 +2494,7 @@ func XpathInt(xml column.Column, path column.Column) column.Column {
 //
 // XpathLong is the Golang equivalent of xpath_long: (xml: 'ColumnOrName', path: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func XpathLong(xml column.Column, path column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("xpath_long", xml, path))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("xpath_long", xml, path))
 }
 
 // XpathShort - Returns a short integer value, or the value zero if no match is found,
@@ -2501,30 +2502,30 @@ func XpathLong(xml column.Column, path column.Column) column.Column {
 //
 // XpathShort is the Golang equivalent of xpath_short: (xml: 'ColumnOrName', path: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func XpathShort(xml column.Column, path column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("xpath_short", xml, path))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("xpath_short", xml, path))
 }
 
 // XpathString - Returns the text contents of the first xml node that matches the XPath expression.
 //
 // XpathString is the Golang equivalent of xpath_string: (xml: 'ColumnOrName', path: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func XpathString(xml column.Column, path column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("xpath_string", xml, path))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("xpath_string", xml, path))
 }
 
 // Trunc - Returns date truncated to the unit specified by the format.
 //
 // Trunc is the Golang equivalent of trunc: (date: 'ColumnOrName', format: str) -> pyspark.sql.connect.column.Column
 func Trunc(date column.Column, format string) column.Column {
-    lit_format := StringLit(format)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("trunc", date, lit_format))
+	lit_format := StringLit(format)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("trunc", date, lit_format))
 }
 
 // DateTrunc - Returns timestamp truncated to the unit specified by the format.
 //
 // DateTrunc is the Golang equivalent of date_trunc: (format: str, timestamp: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func DateTrunc(format string, timestamp column.Column) column.Column {
-    lit_format := StringLit(format)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("date_trunc", lit_format, timestamp))
+	lit_format := StringLit(format)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("date_trunc", lit_format, timestamp))
 }
 
 // NextDay - Returns the first date which is later than the value of the date column
@@ -2532,15 +2533,15 @@ func DateTrunc(format string, timestamp column.Column) column.Column {
 //
 // NextDay is the Golang equivalent of next_day: (date: 'ColumnOrName', dayOfWeek: str) -> pyspark.sql.connect.column.Column
 func NextDay(date column.Column, dayOfWeek string) column.Column {
-    lit_dayOfWeek := StringLit(dayOfWeek)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("next_day", date, lit_dayOfWeek))
+	lit_dayOfWeek := StringLit(dayOfWeek)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("next_day", date, lit_dayOfWeek))
 }
 
 // LastDay - Returns the last day of the month which the given date belongs to.
 //
 // LastDay is the Golang equivalent of last_day: (date: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func LastDay(date column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("last_day", date))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("last_day", date))
 }
 
 // FromUnixtime - Converts the number of seconds from unix epoch (1970-01-01 00:00:00 UTC) to a string
@@ -2549,30 +2550,30 @@ func LastDay(date column.Column) column.Column {
 //
 // FromUnixtime is the Golang equivalent of from_unixtime: (timestamp: 'ColumnOrName', format: str = 'yyyy-MM-dd HH:mm:ss') -> pyspark.sql.connect.column.Column
 func FromUnixtime(timestamp column.Column, format string) column.Column {
-    lit_format := StringLit(format)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("from_unixtime", timestamp, lit_format))
+	lit_format := StringLit(format)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("from_unixtime", timestamp, lit_format))
 }
 
 // UnixTimestamp - Convert time string with given pattern ('yyyy-MM-dd HH:mm:ss', by default)
 // to Unix time stamp (in seconds), using the default timezone and the default
 // locale, returns null if failed.
-// 
+//
 // if `timestamp` is None, then it returns current timestamp.
 //
 // UnixTimestamp is the Golang equivalent of unix_timestamp: (timestamp: Optional[ForwardRef('ColumnOrName')] = None, format: str = 'yyyy-MM-dd HH:mm:ss') -> pyspark.sql.connect.column.Column
 func UnixTimestamp(timestamp column.Column, format string) column.Column {
-    lit_format := StringLit(format)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("unix_timestamp", timestamp, lit_format))
+	lit_format := StringLit(format)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("unix_timestamp", timestamp, lit_format))
 }
 
 // FromUtcTimestamp - This is a common function for databases supporting TIMESTAMP WITHOUT TIMEZONE. This function
 // takes a timestamp which is timezone-agnostic, and interprets it as a timestamp in UTC, and
 // renders that timestamp as a timestamp in the given time zone.
-// 
+//
 // However, timestamp in Spark represents number of microseconds from the Unix epoch, which is not
 // timezone-agnostic. So in Spark this function just shift the timestamp value from UTC timezone to
 // the given timezone.
-// 
+//
 // This function may return confusing result if the input is a string with timezone, e.g.
 // '2018-03-13T06:18:23+00:00'. The reason is that, Spark firstly cast the string to timestamp
 // according to the timezone in the string, and finally display the result by converting the
@@ -2580,17 +2581,17 @@ func UnixTimestamp(timestamp column.Column, format string) column.Column {
 //
 // FromUtcTimestamp is the Golang equivalent of from_utc_timestamp: (timestamp: 'ColumnOrName', tz: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func FromUtcTimestamp(timestamp column.Column, tz column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("from_utc_timestamp", timestamp, tz))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("from_utc_timestamp", timestamp, tz))
 }
 
 // ToUtcTimestamp - This is a common function for databases supporting TIMESTAMP WITHOUT TIMEZONE. This function
 // takes a timestamp which is timezone-agnostic, and interprets it as a timestamp in the given
 // timezone, and renders that timestamp as a timestamp in UTC.
-// 
+//
 // However, timestamp in Spark represents number of microseconds from the Unix epoch, which is not
 // timezone-agnostic. So in Spark this function just shift the timestamp value from the given
 // timezone to UTC timezone.
-// 
+//
 // This function may return confusing result if the input is a string with timezone, e.g.
 // '2018-03-13T06:18:23+00:00'. The reason is that, Spark firstly cast the string to timestamp
 // according to the timezone in the string, and finally display the result by converting the
@@ -2598,7 +2599,7 @@ func FromUtcTimestamp(timestamp column.Column, tz column.Column) column.Column {
 //
 // ToUtcTimestamp is the Golang equivalent of to_utc_timestamp: (timestamp: 'ColumnOrName', tz: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func ToUtcTimestamp(timestamp column.Column, tz column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("to_utc_timestamp", timestamp, tz))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("to_utc_timestamp", timestamp, tz))
 }
 
 // TimestampSeconds - Converts the number of seconds from the Unix epoch (1970-01-01T00:00:00Z)
@@ -2606,59 +2607,60 @@ func ToUtcTimestamp(timestamp column.Column, tz column.Column) column.Column {
 //
 // TimestampSeconds is the Golang equivalent of timestamp_seconds: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func TimestampSeconds(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("timestamp_seconds", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("timestamp_seconds", col))
 }
 
 // TimestampMillis - Creates timestamp from the number of milliseconds since UTC epoch.
 //
 // TimestampMillis is the Golang equivalent of timestamp_millis: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func TimestampMillis(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("timestamp_millis", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("timestamp_millis", col))
 }
 
 // TimestampMicros - Creates timestamp from the number of microseconds since UTC epoch.
 //
 // TimestampMicros is the Golang equivalent of timestamp_micros: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func TimestampMicros(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("timestamp_micros", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("timestamp_micros", col))
 }
 
 // Window - Bucketize rows into one or more time windows given a timestamp specifying column. Window
 // starts are inclusive but the window ends are exclusive, e.g. 12:05 will be in the window
 // [12:05,12:10) but not in [12:00,12:05). Windows can support microsecond precision. Windows in
 // the order of months are not supported.
-// 
+//
 // The time column must be of :class:`pyspark.sql.types.TimestampType`.
-// 
+//
 // Durations are provided as strings, e.g. '1 second', '1 day 12 hours', '2 minutes'. Valid
 // interval strings are 'week', 'day', 'hour', 'minute', 'second', 'millisecond', 'microsecond'.
-// If the ``slideDuration`` is not provided, the windows will be tumbling windows.
-// 
+// If the “slideDuration“ is not provided, the windows will be tumbling windows.
+//
 // The startTime is the offset with respect to 1970-01-01 00:00:00 UTC with which to start
 // window intervals. For example, in order to have hourly tumbling windows that start 15 minutes
 // past the hour, e.g. 12:15-13:15, 13:15-14:15... provide `startTime` as `15 minutes`.
-// 
+//
 // The output column will be a struct called 'window' by default with the nested columns 'start'
 // and 'end', where 'start' and 'end' will be of :class:`pyspark.sql.types.TimestampType`.
 //
 // Window is the Golang equivalent of window: (timeColumn: 'ColumnOrName', windowDuration: str, slideDuration: Optional[str] = None, startTime: Optional[str] = None) -> pyspark.sql.connect.column.Column
 func Window(timeColumn column.Column, windowDuration string, slideDuration string, startTime string) column.Column {
-    lit_windowDuration := StringLit(windowDuration)
-    lit_slideDuration := StringLit(slideDuration)
-    lit_startTime := StringLit(startTime)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("window", timeColumn, lit_windowDuration, lit_slideDuration, lit_startTime))
+	lit_windowDuration := StringLit(windowDuration)
+	lit_slideDuration := StringLit(slideDuration)
+	lit_startTime := StringLit(startTime)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("window", timeColumn,
+		lit_windowDuration, lit_slideDuration, lit_startTime))
 }
 
 // WindowTime - Computes the event time from a window column. The column window values are produced
 // by window aggregating operators and are of type `STRUCT<start: TIMESTAMP, end: TIMESTAMP>`
 // where start is inclusive and end is exclusive. The event time of records produced by window
-// aggregating operators can be computed as ``window_time(window)`` and are
-// ``window.end - lit(1).alias("microsecond")`` (as microsecond is the minimal supported event
+// aggregating operators can be computed as “window_time(window)“ and are
+// “window.end - lit(1).alias("microsecond")“ (as microsecond is the minimal supported event
 // time precision). The window column must be one produced by a window aggregating operator.
 //
 // WindowTime is the Golang equivalent of window_time: (windowColumn: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func WindowTime(windowColumn column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("window_time", windowColumn))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("window_time", windowColumn))
 }
 
 // TODO: session_window: (timeColumn: 'ColumnOrName', gapDuration: Union[pyspark.sql.connect.column.Column, str]) -> pyspark.sql.connect.column.Column
@@ -2667,7 +2669,7 @@ func WindowTime(windowColumn column.Column) column.Column {
 //
 // ToUnixTimestamp is the Golang equivalent of to_unix_timestamp: (timestamp: 'ColumnOrName', format: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
 func ToUnixTimestamp(timestamp column.Column, format column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("to_unix_timestamp", timestamp, format))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("to_unix_timestamp", timestamp, format))
 }
 
 // ToTimestampLtz - Parses the `timestamp` with the `format` to a timestamp without time zone.
@@ -2675,7 +2677,7 @@ func ToUnixTimestamp(timestamp column.Column, format column.Column) column.Colum
 //
 // ToTimestampLtz is the Golang equivalent of to_timestamp_ltz: (timestamp: 'ColumnOrName', format: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
 func ToTimestampLtz(timestamp column.Column, format column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("to_timestamp_ltz", timestamp, format))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("to_timestamp_ltz", timestamp, format))
 }
 
 // ToTimestampNtz - Parses the `timestamp` with the `format` to a timestamp without time zone.
@@ -2683,7 +2685,7 @@ func ToTimestampLtz(timestamp column.Column, format column.Column) column.Column
 //
 // ToTimestampNtz is the Golang equivalent of to_timestamp_ntz: (timestamp: 'ColumnOrName', format: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
 func ToTimestampNtz(timestamp column.Column, format column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("to_timestamp_ntz", timestamp, format))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("to_timestamp_ntz", timestamp, format))
 }
 
 // TODO: bucket: (numBuckets: Union[pyspark.sql.connect.column.Column, int], col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
@@ -2693,7 +2695,7 @@ func ToTimestampNtz(timestamp column.Column, format column.Column) column.Column
 //
 // Years is the Golang equivalent of years: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Years(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("years", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("years", col))
 }
 
 // Months - Partition transform function: A transform for timestamps and dates
@@ -2701,7 +2703,7 @@ func Years(col column.Column) column.Column {
 //
 // Months is the Golang equivalent of months: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Months(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("months", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("months", col))
 }
 
 // Days - Partition transform function: A transform for timestamps and dates
@@ -2709,7 +2711,7 @@ func Months(col column.Column) column.Column {
 //
 // Days is the Golang equivalent of days: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Days(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("days", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("days", col))
 }
 
 // Hours - Partition transform function: A transform for timestamps
@@ -2717,7 +2719,7 @@ func Days(col column.Column) column.Column {
 //
 // Hours is the Golang equivalent of hours: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Hours(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("hours", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("hours", col))
 }
 
 // TODO: convert_timezone: (sourceTz: Optional[pyspark.sql.connect.column.Column], targetTz: pyspark.sql.connect.column.Column, sourceTs: 'ColumnOrName') -> pyspark.sql.connect.column.Column
@@ -2726,14 +2728,17 @@ func Hours(col column.Column) column.Column {
 //
 // MakeDtInterval is the Golang equivalent of make_dt_interval: (days: Optional[ForwardRef('ColumnOrName')] = None, hours: Optional[ForwardRef('ColumnOrName')] = None, mins: Optional[ForwardRef('ColumnOrName')] = None, secs: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
 func MakeDtInterval(days column.Column, hours column.Column, mins column.Column, secs column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("make_dt_interval", days, hours, mins, secs))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("make_dt_interval", days, hours, mins, secs))
 }
 
 // MakeInterval - Make interval from years, months, weeks, days, hours, mins and secs.
 //
 // MakeInterval is the Golang equivalent of make_interval: (years: Optional[ForwardRef('ColumnOrName')] = None, months: Optional[ForwardRef('ColumnOrName')] = None, weeks: Optional[ForwardRef('ColumnOrName')] = None, days: Optional[ForwardRef('ColumnOrName')] = None, hours: Optional[ForwardRef('ColumnOrName')] = None, mins: Optional[ForwardRef('ColumnOrName')] = None, secs: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
-func MakeInterval(years column.Column, months column.Column, weeks column.Column, days column.Column, hours column.Column, mins column.Column, secs column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("make_interval", years, months, weeks, days, hours, mins, secs))
+func MakeInterval(years column.Column, months column.Column, weeks column.Column,
+	days column.Column, hours column.Column, mins column.Column, secs column.Column,
+) column.Column {
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("make_interval", years,
+		months, weeks, days, hours, mins, secs))
 }
 
 // MakeTimestamp - Create timestamp from years, months, days, hours, mins, secs and timezone fields.
@@ -2742,8 +2747,11 @@ func MakeInterval(years column.Column, months column.Column, weeks column.Column
 // on invalid inputs. Otherwise, it will throw an error instead.
 //
 // MakeTimestamp is the Golang equivalent of make_timestamp: (years: 'ColumnOrName', months: 'ColumnOrName', days: 'ColumnOrName', hours: 'ColumnOrName', mins: 'ColumnOrName', secs: 'ColumnOrName', timezone: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
-func MakeTimestamp(years column.Column, months column.Column, days column.Column, hours column.Column, mins column.Column, secs column.Column, timezone column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("make_timestamp", years, months, days, hours, mins, secs, timezone))
+func MakeTimestamp(years column.Column, months column.Column, days column.Column,
+	hours column.Column, mins column.Column, secs column.Column, timezone column.Column,
+) column.Column {
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("make_timestamp", years,
+		months, days, hours, mins, secs, timezone))
 }
 
 // MakeTimestampLtz - Create the current timestamp with local time zone from years, months, days, hours, mins,
@@ -2751,8 +2759,11 @@ func MakeTimestamp(years column.Column, months column.Column, days column.Column
 // the function returns NULL on invalid inputs. Otherwise, it will throw an error instead.
 //
 // MakeTimestampLtz is the Golang equivalent of make_timestamp_ltz: (years: 'ColumnOrName', months: 'ColumnOrName', days: 'ColumnOrName', hours: 'ColumnOrName', mins: 'ColumnOrName', secs: 'ColumnOrName', timezone: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
-func MakeTimestampLtz(years column.Column, months column.Column, days column.Column, hours column.Column, mins column.Column, secs column.Column, timezone column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("make_timestamp_ltz", years, months, days, hours, mins, secs, timezone))
+func MakeTimestampLtz(years column.Column, months column.Column, days column.Column,
+	hours column.Column, mins column.Column, secs column.Column, timezone column.Column,
+) column.Column {
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("make_timestamp_ltz",
+		years, months, days, hours, mins, secs, timezone))
 }
 
 // MakeTimestampNtz - Create local date-time from years, months, days, hours, mins, secs fields.
@@ -2760,50 +2771,53 @@ func MakeTimestampLtz(years column.Column, months column.Column, days column.Col
 // on invalid inputs. Otherwise, it will throw an error instead.
 //
 // MakeTimestampNtz is the Golang equivalent of make_timestamp_ntz: (years: 'ColumnOrName', months: 'ColumnOrName', days: 'ColumnOrName', hours: 'ColumnOrName', mins: 'ColumnOrName', secs: 'ColumnOrName') -> pyspark.sql.connect.column.Column
-func MakeTimestampNtz(years column.Column, months column.Column, days column.Column, hours column.Column, mins column.Column, secs column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("make_timestamp_ntz", years, months, days, hours, mins, secs))
+func MakeTimestampNtz(years column.Column, months column.Column, days column.Column,
+	hours column.Column, mins column.Column, secs column.Column,
+) column.Column {
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("make_timestamp_ntz",
+		years, months, days, hours, mins, secs))
 }
 
 // MakeYmInterval - Make year-month interval from years, months.
 //
 // MakeYmInterval is the Golang equivalent of make_ym_interval: (years: Optional[ForwardRef('ColumnOrName')] = None, months: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
 func MakeYmInterval(years column.Column, months column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("make_ym_interval", years, months))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("make_ym_interval", years, months))
 }
 
 // CurrentCatalog - Returns the current catalog.
 //
 // CurrentCatalog is the Golang equivalent of current_catalog: () -> pyspark.sql.connect.column.Column
 func CurrentCatalog() column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("current_catalog", ))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("current_catalog"))
 }
 
 // CurrentDatabase - Returns the current database.
 //
 // CurrentDatabase is the Golang equivalent of current_database: () -> pyspark.sql.connect.column.Column
 func CurrentDatabase() column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("current_database", ))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("current_database"))
 }
 
 // CurrentSchema - Returns the current database.
 //
 // CurrentSchema is the Golang equivalent of current_schema: () -> pyspark.sql.connect.column.Column
 func CurrentSchema() column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("current_schema", ))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("current_schema"))
 }
 
 // CurrentUser - Returns the current database.
 //
 // CurrentUser is the Golang equivalent of current_user: () -> pyspark.sql.connect.column.Column
 func CurrentUser() column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("current_user", ))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("current_user"))
 }
 
 // User - Returns the current database.
 //
 // User is the Golang equivalent of user: () -> pyspark.sql.connect.column.Column
 func User() column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("user", ))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("user"))
 }
 
 // TODO: assert_true: (col: 'ColumnOrName', errMsg: Union[pyspark.sql.connect.column.Column, str, NoneType] = None) -> pyspark.sql.connect.column.Column
@@ -2815,16 +2829,16 @@ func User() column.Column {
 //
 // Crc32 is the Golang equivalent of crc32: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Crc32(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("crc32", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("crc32", col))
 }
 
 // Hash - Calculates the hash code of given columns, and returns the result as an int column.
 //
 // Hash is the Golang equivalent of hash: (*cols: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Hash(cols ...column.Column) column.Column {
-    vals := make([]column.Column, 0)
-    vals = append(vals, cols...)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("hash", vals...))
+	vals := make([]column.Column, 0)
+	vals = append(vals, cols...)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("hash", vals...))
 }
 
 // Xxhash64 - Calculates the hash code of given columns using the 64-bit variant of the xxHash algorithm,
@@ -2832,23 +2846,23 @@ func Hash(cols ...column.Column) column.Column {
 //
 // Xxhash64 is the Golang equivalent of xxhash64: (*cols: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Xxhash64(cols ...column.Column) column.Column {
-    vals := make([]column.Column, 0)
-    vals = append(vals, cols...)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("xxhash64", vals...))
+	vals := make([]column.Column, 0)
+	vals = append(vals, cols...)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("xxhash64", vals...))
 }
 
 // Md5 - Calculates the MD5 digest and returns the value as a 32 character hex string.
 //
 // Md5 is the Golang equivalent of md5: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Md5(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("md5", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("md5", col))
 }
 
 // Sha1 - Returns the hex string result of SHA-1.
 //
 // Sha1 is the Golang equivalent of sha1: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Sha1(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sha1", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sha1", col))
 }
 
 // Sha2 - Returns the hex string result of SHA-2 family of hash functions (SHA-224, SHA-256, SHA-384,
@@ -2857,8 +2871,8 @@ func Sha1(col column.Column) column.Column {
 //
 // Sha2 is the Golang equivalent of sha2: (col: 'ColumnOrName', numBits: int) -> pyspark.sql.connect.column.Column
 func Sha2(col column.Column, numBits int64) column.Column {
-    lit_numBits := Int64Lit(numBits)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sha2", col, lit_numBits))
+	lit_numBits := Int64Lit(numBits)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sha2", col, lit_numBits))
 }
 
 // TODO: hll_sketch_agg: (col: 'ColumnOrName', lgConfigK: Union[int, pyspark.sql.connect.column.Column, NoneType] = None) -> pyspark.sql.connect.column.Column
@@ -2870,7 +2884,7 @@ func Sha2(col column.Column, numBits int64) column.Column {
 //
 // HllSketchEstimate is the Golang equivalent of hll_sketch_estimate: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func HllSketchEstimate(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("hll_sketch_estimate", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("hll_sketch_estimate", col))
 }
 
 // TODO: hll_union: (col1: 'ColumnOrName', col2: 'ColumnOrName', allowDifferentLgConfigK: Optional[bool] = None) -> pyspark.sql.connect.column.Column
@@ -2879,14 +2893,14 @@ func HllSketchEstimate(col column.Column) column.Column {
 //
 // Ifnull is the Golang equivalent of ifnull: (col1: 'ColumnOrName', col2: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Ifnull(col1 column.Column, col2 column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("ifnull", col1, col2))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("ifnull", col1, col2))
 }
 
 // Isnotnull - Returns true if `col` is not null, or false otherwise.
 //
 // Isnotnull is the Golang equivalent of isnotnull: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Isnotnull(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("isnotnull", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("isnotnull", col))
 }
 
 // EqualNull - Returns same result as the EQUAL(=) operator for non-null operands,
@@ -2894,28 +2908,28 @@ func Isnotnull(col column.Column) column.Column {
 //
 // EqualNull is the Golang equivalent of equal_null: (col1: 'ColumnOrName', col2: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func EqualNull(col1 column.Column, col2 column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("equal_null", col1, col2))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("equal_null", col1, col2))
 }
 
 // Nullif - Returns null if `col1` equals to `col2`, or `col1` otherwise.
 //
 // Nullif is the Golang equivalent of nullif: (col1: 'ColumnOrName', col2: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Nullif(col1 column.Column, col2 column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("nullif", col1, col2))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("nullif", col1, col2))
 }
 
 // Nvl - Returns `col2` if `col1` is null, or `col1` otherwise.
 //
 // Nvl is the Golang equivalent of nvl: (col1: 'ColumnOrName', col2: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Nvl(col1 column.Column, col2 column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("nvl", col1, col2))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("nvl", col1, col2))
 }
 
 // Nvl2 - Returns `col2` if `col1` is not null, or `col3` otherwise.
 //
 // Nvl2 is the Golang equivalent of nvl2: (col1: 'ColumnOrName', col2: 'ColumnOrName', col3: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Nvl2(col1 column.Column, col2 column.Column, col3 column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("nvl2", col1, col2, col3))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("nvl2", col1, col2, col3))
 }
 
 // AesEncrypt - Returns an encrypted value of `input` using AES in given `mode` with the specified `padding`.
@@ -2929,7 +2943,7 @@ func Nvl2(col1 column.Column, col2 column.Column, col3 column.Column) column.Col
 //
 // AesEncrypt is the Golang equivalent of aes_encrypt: (input: 'ColumnOrName', key: 'ColumnOrName', mode: Optional[ForwardRef('ColumnOrName')] = None, padding: Optional[ForwardRef('ColumnOrName')] = None, iv: Optional[ForwardRef('ColumnOrName')] = None, aad: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
 func AesEncrypt(input column.Column, key column.Column, mode column.Column, padding column.Column, iv column.Column, aad column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("aes_encrypt", input, key, mode, padding, iv, aad))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("aes_encrypt", input, key, mode, padding, iv, aad))
 }
 
 // AesDecrypt - Returns a decrypted value of `input` using AES in `mode` with `padding`. Key lengths of 16,
@@ -2940,7 +2954,7 @@ func AesEncrypt(input column.Column, key column.Column, mode column.Column, padd
 //
 // AesDecrypt is the Golang equivalent of aes_decrypt: (input: 'ColumnOrName', key: 'ColumnOrName', mode: Optional[ForwardRef('ColumnOrName')] = None, padding: Optional[ForwardRef('ColumnOrName')] = None, aad: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
 func AesDecrypt(input column.Column, key column.Column, mode column.Column, padding column.Column, aad column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("aes_decrypt", input, key, mode, padding, aad))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("aes_decrypt", input, key, mode, padding, aad))
 }
 
 // TryAesDecrypt - This is a special version of `aes_decrypt` that performs the same operation,
@@ -2953,46 +2967,46 @@ func AesDecrypt(input column.Column, key column.Column, mode column.Column, padd
 //
 // TryAesDecrypt is the Golang equivalent of try_aes_decrypt: (input: 'ColumnOrName', key: 'ColumnOrName', mode: Optional[ForwardRef('ColumnOrName')] = None, padding: Optional[ForwardRef('ColumnOrName')] = None, aad: Optional[ForwardRef('ColumnOrName')] = None) -> pyspark.sql.connect.column.Column
 func TryAesDecrypt(input column.Column, key column.Column, mode column.Column, padding column.Column, aad column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_aes_decrypt", input, key, mode, padding, aad))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("try_aes_decrypt", input, key, mode, padding, aad))
 }
 
 // Sha - Returns a sha1 hash value as a hex string of the `col`.
 //
 // Sha is the Golang equivalent of sha: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Sha(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sha", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("sha", col))
 }
 
 // InputFileBlockLength - Returns the length of the block being read, or -1 if not available.
 //
 // InputFileBlockLength is the Golang equivalent of input_file_block_length: () -> pyspark.sql.connect.column.Column
 func InputFileBlockLength() column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("input_file_block_length", ))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("input_file_block_length"))
 }
 
 // InputFileBlockStart - Returns the start offset of the block being read, or -1 if not available.
 //
 // InputFileBlockStart is the Golang equivalent of input_file_block_start: () -> pyspark.sql.connect.column.Column
 func InputFileBlockStart() column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("input_file_block_start", ))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("input_file_block_start"))
 }
 
 // Reflect - Calls a method with reflection.
 //
 // Reflect is the Golang equivalent of reflect: (*cols: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Reflect(cols ...column.Column) column.Column {
-    vals := make([]column.Column, 0)
-    vals = append(vals, cols...)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("reflect", vals...))
+	vals := make([]column.Column, 0)
+	vals = append(vals, cols...)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("reflect", vals...))
 }
 
 // JavaMethod - Calls a method with reflection.
 //
 // JavaMethod is the Golang equivalent of java_method: (*cols: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func JavaMethod(cols ...column.Column) column.Column {
-    vals := make([]column.Column, 0)
-    vals = append(vals, cols...)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("java_method", vals...))
+	vals := make([]column.Column, 0)
+	vals = append(vals, cols...)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("java_method", vals...))
 }
 
 // Version - Returns the Spark version. The string contains 2 fields, the first being a release version
@@ -3000,14 +3014,14 @@ func JavaMethod(cols ...column.Column) column.Column {
 //
 // Version is the Golang equivalent of version: () -> pyspark.sql.connect.column.Column
 func Version() column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("version", ))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("version"))
 }
 
 // Typeof - Return DDL-formatted type string for the data type of the input.
 //
 // Typeof is the Golang equivalent of typeof: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Typeof(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("typeof", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("typeof", col))
 }
 
 // Stack - Separates `col1`, ..., `colk` into `n` rows. Uses column names col0, col1, etc. by default
@@ -3015,23 +3029,23 @@ func Typeof(col column.Column) column.Column {
 //
 // Stack is the Golang equivalent of stack: (*cols: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func Stack(cols ...column.Column) column.Column {
-    vals := make([]column.Column, 0)
-    vals = append(vals, cols...)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("stack", vals...))
+	vals := make([]column.Column, 0)
+	vals = append(vals, cols...)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("stack", vals...))
 }
 
 // BitmapBitPosition - Returns the bit position for the given input column.
 //
 // BitmapBitPosition is the Golang equivalent of bitmap_bit_position: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func BitmapBitPosition(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bitmap_bit_position", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bitmap_bit_position", col))
 }
 
 // BitmapBucketNumber - Returns the bucket number for the given input column.
 //
 // BitmapBucketNumber is the Golang equivalent of bitmap_bucket_number: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func BitmapBucketNumber(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bitmap_bucket_number", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bitmap_bucket_number", col))
 }
 
 // BitmapConstructAgg - Returns a bitmap with the positions of the bits set from all the values from the input column.
@@ -3039,14 +3053,14 @@ func BitmapBucketNumber(col column.Column) column.Column {
 //
 // BitmapConstructAgg is the Golang equivalent of bitmap_construct_agg: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func BitmapConstructAgg(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bitmap_construct_agg", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bitmap_construct_agg", col))
 }
 
 // BitmapCount - Returns the number of set bits in the input bitmap.
 //
 // BitmapCount is the Golang equivalent of bitmap_count: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func BitmapCount(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bitmap_count", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bitmap_count", col))
 }
 
 // BitmapOrAgg - Returns a bitmap that is the bitwise OR of all of the bitmaps from the input column.
@@ -3054,7 +3068,7 @@ func BitmapCount(col column.Column) column.Column {
 //
 // BitmapOrAgg is the Golang equivalent of bitmap_or_agg: (col: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func BitmapOrAgg(col column.Column) column.Column {
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bitmap_or_agg", col))
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("bitmap_or_agg", col))
 }
 
 // Ignore UDF: call_udf: (udfName: str, *cols: 'ColumnOrName') -> pyspark.sql.connect.column.Column
@@ -3069,10 +3083,9 @@ func BitmapOrAgg(col column.Column) column.Column {
 //
 // CallFunction is the Golang equivalent of call_function: (funcName: str, *cols: 'ColumnOrName') -> pyspark.sql.connect.column.Column
 func CallFunction(funcName string, cols ...column.Column) column.Column {
-    lit_funcName := StringLit(funcName)
-    vals := make([]column.Column, 0)
-    vals = append(vals, lit_funcName)
-    vals = append(vals, cols...)
-    return column.NewColumn(column.NewUnresolvedFunctionWithColumns("call_function", vals...))
+	lit_funcName := StringLit(funcName)
+	vals := make([]column.Column, 0)
+	vals = append(vals, lit_funcName)
+	vals = append(vals, cols...)
+	return column.NewColumn(column.NewUnresolvedFunctionWithColumns("call_function", vals...))
 }
-

--- a/spark/sql/group.go
+++ b/spark/sql/group.go
@@ -18,6 +18,7 @@ package sql
 
 import (
 	"context"
+
 	"github.com/apache/spark-connect-go/v35/spark/sql/types"
 
 	proto "github.com/apache/spark-connect-go/v35/internal/generated"

--- a/spark/sql/group.go
+++ b/spark/sql/group.go
@@ -18,6 +18,7 @@ package sql
 
 import (
 	"context"
+	"github.com/apache/spark-connect-go/v35/spark/sql/types"
 
 	proto "github.com/apache/spark-connect-go/v35/internal/generated"
 	"github.com/apache/spark-connect-go/v35/spark/sparkerrors"
@@ -29,7 +30,7 @@ type GroupedData struct {
 	df           *dataFrameImpl
 	groupType    string
 	groupingCols []column.Convertible
-	pivotValues  []any
+	pivotValues  []types.LiteralType
 	pivotCol     column.Convertible
 }
 
@@ -171,7 +172,7 @@ func (gd *GroupedData) Sum(ctx context.Context, cols ...string) (DataFrame, erro
 
 // Count Computes the count value for each group.
 func (gd *GroupedData) Count(ctx context.Context) (DataFrame, error) {
-	return gd.Agg(ctx, functions.Count(functions.Lit(1)).Alias("count"))
+	return gd.Agg(ctx, functions.Count(functions.Lit(types.Int64(1))).Alias("count"))
 }
 
 // Mean Computes the average value for each numeric column for each group.
@@ -179,7 +180,7 @@ func (gd *GroupedData) Mean(ctx context.Context, cols ...string) (DataFrame, err
 	return gd.Avg(ctx, cols...)
 }
 
-func (gd *GroupedData) Pivot(ctx context.Context, pivotCol string, pivotValues []any) (*GroupedData, error) {
+func (gd *GroupedData) Pivot(ctx context.Context, pivotCol string, pivotValues []types.LiteralType) (*GroupedData, error) {
 	if gd.groupType != "groupby" {
 		if gd.groupType == "pivot" {
 			return nil, sparkerrors.WithString(sparkerrors.InvalidInputError, "pivot cannot be applied on pivot")

--- a/spark/sql/sparksession.go
+++ b/spark/sql/sparksession.go
@@ -230,6 +230,10 @@ func (s *sparkSessionImpl) CreateDataFrame(ctx context.Context, data [][]any, sc
 	// Iterate over all fields and add the values:
 	for _, row := range data {
 		for i, field := range schema.Fields {
+			if row[i] == nil {
+				rb.Field(i).AppendNull()
+				continue
+			}
 			switch field.DataType {
 			case types.BOOLEAN:
 				rb.Field(i).(*array.BooleanBuilder).Append(row[i].(bool))

--- a/spark/sql/types/arrow.go
+++ b/spark/sql/types/arrow.go
@@ -75,77 +75,137 @@ func readArrayData(t arrow.Type, data arrow.ArrayData) ([]any, error) {
 	case arrow.BOOL:
 		data := array.NewBooleanData(data)
 		for i := 0; i < data.Len(); i++ {
-			buf = append(buf, data.Value(i))
+			if data.IsNull(i) {
+				buf = append(buf, nil)
+			} else {
+				buf = append(buf, data.Value(i))
+			}
 		}
 	case arrow.INT8:
 		data := array.NewInt8Data(data)
 		for i := 0; i < data.Len(); i++ {
-			buf = append(buf, data.Value(i))
+			if data.IsNull(i) {
+				buf = append(buf, nil)
+			} else {
+				buf = append(buf, data.Value(i))
+			}
 		}
 	case arrow.INT16:
 		data := array.NewInt16Data(data)
 		for i := 0; i < data.Len(); i++ {
-			buf = append(buf, data.Value(i))
+			if data.IsNull(i) {
+				buf = append(buf, nil)
+			} else {
+				buf = append(buf, data.Value(i))
+			}
 		}
 	case arrow.INT32:
 		data := array.NewInt32Data(data)
 		for i := 0; i < data.Len(); i++ {
-			buf = append(buf, data.Value(i))
+			if data.IsNull(i) {
+				buf = append(buf, nil)
+			} else {
+				buf = append(buf, data.Value(i))
+			}
 		}
 	case arrow.INT64:
 		data := array.NewInt64Data(data)
 		for i := 0; i < data.Len(); i++ {
-			buf = append(buf, data.Value(i))
+			if data.IsNull(i) {
+				buf = append(buf, nil)
+			} else {
+				buf = append(buf, data.Value(i))
+			}
 		}
 	case arrow.FLOAT16:
 		data := array.NewFloat16Data(data)
 		for i := 0; i < data.Len(); i++ {
-			buf = append(buf, data.Value(i))
+			if data.IsNull(i) {
+				buf = append(buf, nil)
+			} else {
+				buf = append(buf, data.Value(i))
+			}
 		}
 	case arrow.FLOAT32:
 		data := array.NewFloat32Data(data)
 		for i := 0; i < data.Len(); i++ {
-			buf = append(buf, data.Value(i))
+			if data.IsNull(i) {
+				buf = append(buf, nil)
+			} else {
+				buf = append(buf, data.Value(i))
+			}
 		}
 	case arrow.FLOAT64:
 		data := array.NewFloat64Data(data)
 		for i := 0; i < data.Len(); i++ {
-			buf = append(buf, data.Value(i))
+			if data.IsNull(i) {
+				buf = append(buf, nil)
+			} else {
+				buf = append(buf, data.Value(i))
+			}
 		}
 	case arrow.DECIMAL | arrow.DECIMAL128:
 		data := array.NewDecimal128Data(data)
 		for i := 0; i < data.Len(); i++ {
-			buf = append(buf, data.Value(i))
+			if data.IsNull(i) {
+				buf = append(buf, nil)
+			} else {
+				buf = append(buf, data.Value(i))
+			}
 		}
 	case arrow.DECIMAL256:
 		data := array.NewDecimal256Data(data)
 		for i := 0; i < data.Len(); i++ {
-			buf = append(buf, data.Value(i))
+			if data.IsNull(i) {
+				buf = append(buf, nil)
+			} else {
+				buf = append(buf, data.Value(i))
+			}
 		}
 	case arrow.STRING:
 		data := array.NewStringData(data)
 		for i := 0; i < data.Len(); i++ {
-			buf = append(buf, data.Value(i))
+			if data.IsNull(i) {
+				buf = append(buf, nil)
+			} else {
+				buf = append(buf, data.Value(i))
+			}
 		}
 	case arrow.BINARY:
 		data := array.NewBinaryData(data)
 		for i := 0; i < data.Len(); i++ {
-			buf = append(buf, data.Value(i))
+			if data.IsNull(i) {
+				buf = append(buf, nil)
+			} else {
+				buf = append(buf, data.Value(i))
+			}
 		}
 	case arrow.TIMESTAMP:
 		data := array.NewTimestampData(data)
 		for i := 0; i < data.Len(); i++ {
-			buf = append(buf, data.Value(i))
+			if data.IsNull(i) {
+				buf = append(buf, nil)
+			} else {
+				buf = append(buf, data.Value(i))
+			}
 		}
 	case arrow.DATE64:
 		data := array.NewDate64Data(data)
 		for i := 0; i < data.Len(); i++ {
-			buf = append(buf, data.Value(i))
+			if data.IsNull(i) {
+				buf = append(buf, nil)
+			} else {
+				buf = append(buf, data.Value(i))
+			}
 		}
 	case arrow.DATE32:
 		data := array.NewDate32Data(data)
 		for i := 0; i < data.Len(); i++ {
-			buf = append(buf, data.Value(i))
+			if data.IsNull(i) {
+				buf = append(buf, nil)
+			} else {
+				buf = append(buf, data.Value(i))
+			}
 		}
 	case arrow.LIST:
 		data := array.NewListData(data)

--- a/spark/sql/types/builtin.go
+++ b/spark/sql/types/builtin.go
@@ -183,13 +183,15 @@ func (t Binary) ToProto(ctx context.Context) (*proto.Expression, error) {
 	}, nil
 }
 
-type Int8Nil struct{}
+type Int8NilType struct{}
 
-func (t Int8Nil) isNumericLiteral() {}
+var Int8Nil = Int8NilType{}
 
-func (t Int8Nil) isPrimitiveTypeLiteral() {}
+func (t Int8NilType) isNumericLiteral() {}
 
-func (t Int8Nil) ToProto(ctx context.Context) (*proto.Expression, error) {
+func (t Int8NilType) isPrimitiveTypeLiteral() {}
+
+func (t Int8NilType) ToProto(ctx context.Context) (*proto.Expression, error) {
 	return &proto.Expression{
 		ExprType: &proto.Expression_Literal_{
 			Literal: &proto.Expression_Literal{
@@ -205,13 +207,15 @@ func (t Int8Nil) ToProto(ctx context.Context) (*proto.Expression, error) {
 	}, nil
 }
 
-type Int16Nil struct{}
+type Int16NilType struct{}
 
-func (t Int16Nil) isNumericLiteral() {}
+var Int16Nil = Int16NilType{}
 
-func (t Int16Nil) isPrimitiveTypeLiteral() {}
+func (t Int16NilType) isNumericLiteral() {}
 
-func (t Int16Nil) ToProto(ctx context.Context) (*proto.Expression, error) {
+func (t Int16NilType) isPrimitiveTypeLiteral() {}
+
+func (t Int16NilType) ToProto(ctx context.Context) (*proto.Expression, error) {
 	return &proto.Expression{
 		ExprType: &proto.Expression_Literal_{
 			Literal: &proto.Expression_Literal{
@@ -227,13 +231,15 @@ func (t Int16Nil) ToProto(ctx context.Context) (*proto.Expression, error) {
 	}, nil
 }
 
-type Int32Nil struct{}
+type Int32NilType struct{}
 
-func (t Int32Nil) isNumericLiteral() {}
+var Int32Nil = Int32NilType{}
 
-func (t Int32Nil) isPrimitiveTypeLiteral() {}
+func (t Int32NilType) isNumericLiteral() {}
 
-func (t Int32Nil) ToProto(ctx context.Context) (*proto.Expression, error) {
+func (t Int32NilType) isPrimitiveTypeLiteral() {}
+
+func (t Int32NilType) ToProto(ctx context.Context) (*proto.Expression, error) {
 	return &proto.Expression{
 		ExprType: &proto.Expression_Literal_{
 			Literal: &proto.Expression_Literal{
@@ -249,13 +255,15 @@ func (t Int32Nil) ToProto(ctx context.Context) (*proto.Expression, error) {
 	}, nil
 }
 
-type Int64Nil struct{}
+type Int64NilType struct{}
 
-func (t Int64Nil) isNumericLiteral() {}
+var Int64Nil = Int64NilType{}
 
-func (t Int64Nil) isPrimitiveTypeLiteral() {}
+func (t Int64NilType) isNumericLiteral() {}
 
-func (t Int64Nil) ToProto(ctx context.Context) (*proto.Expression, error) {
+func (t Int64NilType) isPrimitiveTypeLiteral() {}
+
+func (t Int64NilType) ToProto(ctx context.Context) (*proto.Expression, error) {
 	return &proto.Expression{
 		ExprType: &proto.Expression_Literal_{
 			Literal: &proto.Expression_Literal{
@@ -271,23 +279,27 @@ func (t Int64Nil) ToProto(ctx context.Context) (*proto.Expression, error) {
 	}, nil
 }
 
-type IntNil struct{}
+type IntNilType struct{}
 
-func (t IntNil) isNumericLiteral() {}
+var IntNil = IntNilType{}
 
-func (t IntNil) isPrimitiveTypeLiteral() {}
+func (t IntNilType) isNumericLiteral() {}
 
-func (t IntNil) ToProto(ctx context.Context) (*proto.Expression, error) {
-	return Int64Nil{}.ToProto(ctx)
+func (t IntNilType) isPrimitiveTypeLiteral() {}
+
+func (t IntNilType) ToProto(ctx context.Context) (*proto.Expression, error) {
+	return Int64NilType{}.ToProto(ctx)
 }
 
-type Float32Nil struct{}
+type Float32NilType struct{}
 
-func (t Float32Nil) isNumericLiteral() {}
+var Float32Nil = Float32NilType{}
 
-func (t Float32Nil) isPrimitiveTypeLiteral() {}
+func (t Float32NilType) isNumericLiteral() {}
 
-func (t Float32Nil) ToProto(ctx context.Context) (*proto.Expression, error) {
+func (t Float32NilType) isPrimitiveTypeLiteral() {}
+
+func (t Float32NilType) ToProto(ctx context.Context) (*proto.Expression, error) {
 	return &proto.Expression{
 		ExprType: &proto.Expression_Literal_{
 			Literal: &proto.Expression_Literal{
@@ -303,13 +315,15 @@ func (t Float32Nil) ToProto(ctx context.Context) (*proto.Expression, error) {
 	}, nil
 }
 
-type Float64Nil struct{}
+type Float64NilType struct{}
 
-func (t Float64Nil) isNumericLiteral() {}
+var Float64Nil = Float64NilType{}
 
-func (t Float64Nil) isPrimitiveTypeLiteral() {}
+func (t Float64NilType) isNumericLiteral() {}
 
-func (t Float64Nil) ToProto(ctx context.Context) (*proto.Expression, error) {
+func (t Float64NilType) isPrimitiveTypeLiteral() {}
+
+func (t Float64NilType) ToProto(ctx context.Context) (*proto.Expression, error) {
 	return &proto.Expression{
 		ExprType: &proto.Expression_Literal_{
 			Literal: &proto.Expression_Literal{
@@ -325,11 +339,13 @@ func (t Float64Nil) ToProto(ctx context.Context) (*proto.Expression, error) {
 	}, nil
 }
 
-type StringNil struct{}
+type StringNilType struct{}
 
-func (t StringNil) isPrimitiveTypeLiteral() {}
+var StringNil = StringNilType{}
 
-func (t StringNil) ToProto(ctx context.Context) (*proto.Expression, error) {
+func (t StringNilType) isPrimitiveTypeLiteral() {}
+
+func (t StringNilType) ToProto(ctx context.Context) (*proto.Expression, error) {
 	return &proto.Expression{
 		ExprType: &proto.Expression_Literal_{
 			Literal: &proto.Expression_Literal{
@@ -345,11 +361,13 @@ func (t StringNil) ToProto(ctx context.Context) (*proto.Expression, error) {
 	}, nil
 }
 
-type BooleanNil struct{}
+type BooleanNilType struct{}
 
-func (t BooleanNil) isPrimitiveTypeLiteral() {}
+var BooleanNil = BooleanNilType{}
 
-func (t BooleanNil) ToProto(ctx context.Context) (*proto.Expression, error) {
+func (t BooleanNilType) isPrimitiveTypeLiteral() {}
+
+func (t BooleanNilType) ToProto(ctx context.Context) (*proto.Expression, error) {
 	return &proto.Expression{
 		ExprType: &proto.Expression_Literal_{
 			Literal: &proto.Expression_Literal{
@@ -365,9 +383,11 @@ func (t BooleanNil) ToProto(ctx context.Context) (*proto.Expression, error) {
 	}, nil
 }
 
-type BinaryNil struct{}
+type BinaryNilType struct{}
 
-func (t BinaryNil) ToProto(ctx context.Context) (*proto.Expression, error) {
+var BinaryNil = BinaryNilType{}
+
+func (t BinaryNilType) ToProto(ctx context.Context) (*proto.Expression, error) {
 	return &proto.Expression{
 		ExprType: &proto.Expression_Literal_{
 			Literal: &proto.Expression_Literal{

--- a/spark/sql/types/builtin.go
+++ b/spark/sql/types/builtin.go
@@ -18,6 +18,7 @@ package types
 
 import (
 	"context"
+
 	proto "github.com/apache/spark-connect-go/v35/internal/generated"
 )
 
@@ -177,6 +178,206 @@ func (t Binary) ToProto(ctx context.Context) (*proto.Expression, error) {
 		ExprType: &proto.Expression_Literal_{
 			Literal: &proto.Expression_Literal{
 				LiteralType: &proto.Expression_Literal_Binary{Binary: t},
+			},
+		},
+	}, nil
+}
+
+type Int8Nil struct{}
+
+func (t Int8Nil) isNumericLiteral() {}
+
+func (t Int8Nil) isPrimitiveTypeLiteral() {}
+
+func (t Int8Nil) ToProto(ctx context.Context) (*proto.Expression, error) {
+	return &proto.Expression{
+		ExprType: &proto.Expression_Literal_{
+			Literal: &proto.Expression_Literal{
+				LiteralType: &proto.Expression_Literal_Null{
+					Null: &proto.DataType{
+						Kind: &proto.DataType_Byte_{
+							Byte: &proto.DataType_Byte{},
+						},
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+type Int16Nil struct{}
+
+func (t Int16Nil) isNumericLiteral() {}
+
+func (t Int16Nil) isPrimitiveTypeLiteral() {}
+
+func (t Int16Nil) ToProto(ctx context.Context) (*proto.Expression, error) {
+	return &proto.Expression{
+		ExprType: &proto.Expression_Literal_{
+			Literal: &proto.Expression_Literal{
+				LiteralType: &proto.Expression_Literal_Null{
+					Null: &proto.DataType{
+						Kind: &proto.DataType_Short_{
+							Short: &proto.DataType_Short{},
+						},
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+type Int32Nil struct{}
+
+func (t Int32Nil) isNumericLiteral() {}
+
+func (t Int32Nil) isPrimitiveTypeLiteral() {}
+
+func (t Int32Nil) ToProto(ctx context.Context) (*proto.Expression, error) {
+	return &proto.Expression{
+		ExprType: &proto.Expression_Literal_{
+			Literal: &proto.Expression_Literal{
+				LiteralType: &proto.Expression_Literal_Null{
+					Null: &proto.DataType{
+						Kind: &proto.DataType_Integer_{
+							Integer: &proto.DataType_Integer{},
+						},
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+type Int64Nil struct{}
+
+func (t Int64Nil) isNumericLiteral() {}
+
+func (t Int64Nil) isPrimitiveTypeLiteral() {}
+
+func (t Int64Nil) ToProto(ctx context.Context) (*proto.Expression, error) {
+	return &proto.Expression{
+		ExprType: &proto.Expression_Literal_{
+			Literal: &proto.Expression_Literal{
+				LiteralType: &proto.Expression_Literal_Null{
+					Null: &proto.DataType{
+						Kind: &proto.DataType_Long_{
+							Long: &proto.DataType_Long{},
+						},
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+type IntNil struct{}
+
+func (t IntNil) isNumericLiteral() {}
+
+func (t IntNil) isPrimitiveTypeLiteral() {}
+
+func (t IntNil) ToProto(ctx context.Context) (*proto.Expression, error) {
+	return Int64Nil{}.ToProto(ctx)
+}
+
+type Float32Nil struct{}
+
+func (t Float32Nil) isNumericLiteral() {}
+
+func (t Float32Nil) isPrimitiveTypeLiteral() {}
+
+func (t Float32Nil) ToProto(ctx context.Context) (*proto.Expression, error) {
+	return &proto.Expression{
+		ExprType: &proto.Expression_Literal_{
+			Literal: &proto.Expression_Literal{
+				LiteralType: &proto.Expression_Literal_Null{
+					Null: &proto.DataType{
+						Kind: &proto.DataType_Float_{
+							Float: &proto.DataType_Float{},
+						},
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+type Float64Nil struct{}
+
+func (t Float64Nil) isNumericLiteral() {}
+
+func (t Float64Nil) isPrimitiveTypeLiteral() {}
+
+func (t Float64Nil) ToProto(ctx context.Context) (*proto.Expression, error) {
+	return &proto.Expression{
+		ExprType: &proto.Expression_Literal_{
+			Literal: &proto.Expression_Literal{
+				LiteralType: &proto.Expression_Literal_Null{
+					Null: &proto.DataType{
+						Kind: &proto.DataType_Double_{
+							Double: &proto.DataType_Double{},
+						},
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+type StringNil struct{}
+
+func (t StringNil) isPrimitiveTypeLiteral() {}
+
+func (t StringNil) ToProto(ctx context.Context) (*proto.Expression, error) {
+	return &proto.Expression{
+		ExprType: &proto.Expression_Literal_{
+			Literal: &proto.Expression_Literal{
+				LiteralType: &proto.Expression_Literal_Null{
+					Null: &proto.DataType{
+						Kind: &proto.DataType_String_{
+							String_: &proto.DataType_String{},
+						},
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+type BooleanNil struct{}
+
+func (t BooleanNil) isPrimitiveTypeLiteral() {}
+
+func (t BooleanNil) ToProto(ctx context.Context) (*proto.Expression, error) {
+	return &proto.Expression{
+		ExprType: &proto.Expression_Literal_{
+			Literal: &proto.Expression_Literal{
+				LiteralType: &proto.Expression_Literal_Null{
+					Null: &proto.DataType{
+						Kind: &proto.DataType_Boolean_{
+							Boolean: &proto.DataType_Boolean{},
+						},
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+type BinaryNil struct{}
+
+func (t BinaryNil) ToProto(ctx context.Context) (*proto.Expression, error) {
+	return &proto.Expression{
+		ExprType: &proto.Expression_Literal_{
+			Literal: &proto.Expression_Literal{
+				LiteralType: &proto.Expression_Literal_Null{
+					Null: &proto.DataType{
+						Kind: &proto.DataType_Binary_{
+							Binary: &proto.DataType_Binary{},
+						},
+					},
+				},
 			},
 		},
 	}, nil

--- a/spark/sql/types/builtin.go
+++ b/spark/sql/types/builtin.go
@@ -1,0 +1,183 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"context"
+	proto "github.com/apache/spark-connect-go/v35/internal/generated"
+)
+
+type LiteralType interface {
+	ToProto(ctx context.Context) (*proto.Expression, error)
+}
+
+type NumericLiteral interface {
+	LiteralType
+	// marker method for compile time safety.
+	isNumericLiteral()
+}
+
+type PrimitiveTypeLiteral interface {
+	LiteralType
+	isPrimitiveTypeLiteral()
+}
+
+type Int8 int8
+
+func (t Int8) ToProto(ctx context.Context) (*proto.Expression, error) {
+	return &proto.Expression{
+		ExprType: &proto.Expression_Literal_{
+			Literal: &proto.Expression_Literal{
+				LiteralType: &proto.Expression_Literal_Byte{Byte: int32(t)},
+			},
+		},
+	}, nil
+}
+
+func (t Int8) isNumericLiteral() {}
+
+func (t Int8) isPrimitiveTypeLiteral() {}
+
+type Int16 int16
+
+func (t Int16) ToProto(ctx context.Context) (*proto.Expression, error) {
+	return &proto.Expression{
+		ExprType: &proto.Expression_Literal_{
+			Literal: &proto.Expression_Literal{
+				LiteralType: &proto.Expression_Literal_Short{Short: int32(t)},
+			},
+		},
+	}, nil
+}
+
+func (t Int16) isNumericLiteral() {}
+
+func (t Int16) isPrimitiveTypeLiteral() {}
+
+type Int32 int32
+
+func (t Int32) ToProto(ctx context.Context) (*proto.Expression, error) {
+	return &proto.Expression{
+		ExprType: &proto.Expression_Literal_{
+			Literal: &proto.Expression_Literal{
+				LiteralType: &proto.Expression_Literal_Integer{Integer: int32(t)},
+			},
+		},
+	}, nil
+}
+
+func (t Int32) isNumericLiteral() {}
+
+func (t Int32) isPrimitiveTypeLiteral() {}
+
+type Int64 int64
+
+func (t Int64) ToProto(ctx context.Context) (*proto.Expression, error) {
+	return &proto.Expression{
+		ExprType: &proto.Expression_Literal_{
+			Literal: &proto.Expression_Literal{
+				LiteralType: &proto.Expression_Literal_Long{Long: int64(t)},
+			},
+		},
+	}, nil
+}
+
+func (t Int64) isNumericLiteral() {}
+
+func (t Int64) isPrimitiveTypeLiteral() {}
+
+type Int int
+
+func (t Int) ToProto(ctx context.Context) (*proto.Expression, error) {
+	return Int64(t).ToProto(ctx)
+}
+
+func (t Int) isNumericLiteral() {}
+
+func (t Int) isPrimitiveTypeLiteral() {}
+
+type Float32 float32
+
+func (t Float32) ToProto(ctx context.Context) (*proto.Expression, error) {
+	return &proto.Expression{
+		ExprType: &proto.Expression_Literal_{
+			Literal: &proto.Expression_Literal{
+				LiteralType: &proto.Expression_Literal_Float{Float: float32(t)},
+			},
+		},
+	}, nil
+}
+
+func (t Float32) isNumericLiteral() {}
+
+func (t Float32) isPrimitiveTypeLiteral() {}
+
+type Float64 float64
+
+func (t Float64) ToProto(ctx context.Context) (*proto.Expression, error) {
+	return &proto.Expression{
+		ExprType: &proto.Expression_Literal_{
+			Literal: &proto.Expression_Literal{
+				LiteralType: &proto.Expression_Literal_Double{Double: float64(t)},
+			},
+		},
+	}, nil
+}
+
+func (t Float64) isNumericLiteral() {}
+
+func (t Float64) isPrimitiveTypeLiteral() {}
+
+type String string
+
+func (t String) ToProto(ctx context.Context) (*proto.Expression, error) {
+	return &proto.Expression{
+		ExprType: &proto.Expression_Literal_{
+			Literal: &proto.Expression_Literal{
+				LiteralType: &proto.Expression_Literal_String_{String_: string(t)},
+			},
+		},
+	}, nil
+}
+
+func (t String) isPrimitiveTypeLiteral() {}
+
+type Boolean bool
+
+func (t Boolean) ToProto(ctx context.Context) (*proto.Expression, error) {
+	return &proto.Expression{
+		ExprType: &proto.Expression_Literal_{
+			Literal: &proto.Expression_Literal{
+				LiteralType: &proto.Expression_Literal_Boolean{Boolean: bool(t)},
+			},
+		},
+	}, nil
+}
+
+func (t Boolean) isPrimitiveTypeLiteral() {}
+
+type Binary []byte
+
+func (t Binary) ToProto(ctx context.Context) (*proto.Expression, error) {
+	return &proto.Expression{
+		ExprType: &proto.Expression_Literal_{
+			Literal: &proto.Expression_Literal{
+				LiteralType: &proto.Expression_Literal_Binary{Binary: t},
+			},
+		},
+	}, nil
+}

--- a/spark/sql/types/builtin_test.go
+++ b/spark/sql/types/builtin_test.go
@@ -1,0 +1,82 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestBuiltinTypes(t *testing.T) {
+
+	p, err := Int8(1).ToProto(nil)
+	assert.NoError(t, err)
+	assert.Equal(t, p.GetLiteral().GetByte(), int32(1))
+
+	p, err = Int16(1).ToProto(nil)
+	assert.NoError(t, err)
+	assert.Equal(t, p.GetLiteral().GetShort(), int32(1))
+
+	p, err = Int32(1).ToProto(nil)
+	assert.NoError(t, err)
+	assert.Equal(t, p.GetLiteral().GetInteger(), int32(1))
+
+	p, err = Int64(1).ToProto(nil)
+	assert.NoError(t, err)
+	assert.Equal(t, p.GetLiteral().GetLong(), int64(1))
+
+	p, err = Float32(1.0).ToProto(nil)
+	assert.NoError(t, err)
+	assert.Equal(t, p.GetLiteral().GetFloat(), float32(1.0))
+
+	p, err = Float64(1.0).ToProto(nil)
+	assert.NoError(t, err)
+	assert.Equal(t, p.GetLiteral().GetDouble(), float64(1.0))
+
+	p, err = String("1").ToProto(nil)
+	assert.NoError(t, err)
+	assert.Equal(t, p.GetLiteral().GetString_(), "1")
+
+	p, err = Boolean(true).ToProto(nil)
+	assert.NoError(t, err)
+	assert.Equal(t, p.GetLiteral().GetBoolean(), true)
+
+	p, err = Binary([]byte{1}).ToProto(nil)
+	assert.NoError(t, err)
+	assert.Equal(t, p.GetLiteral().GetBinary(), []byte{1})
+}
+
+func testMe(n NumericLiteral) bool {
+	return true
+}
+
+func testPrimitive(p PrimitiveTypeLiteral) bool {
+	return true
+}
+
+func TestNumericTypes(t *testing.T) {
+	assert.True(t, testMe(Int8(1)))
+	assert.True(t, testMe(Int16(1)))
+	assert.True(t, testMe(Int32(1)))
+	assert.True(t, testMe(Int64(1)))
+	assert.True(t, testMe(Float32(1.0)))
+	assert.True(t, testMe(Float64(1.0)))
+
+	assert.True(t, testPrimitive(String("a")))
+	assert.True(t, testPrimitive(Boolean(true)))
+	assert.True(t, testPrimitive(Int16(1)))
+}

--- a/spark/sql/types/builtin_test.go
+++ b/spark/sql/types/builtin_test.go
@@ -17,45 +17,46 @@
 package types
 
 import (
-	"github.com/stretchr/testify/assert"
+	"context"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBuiltinTypes(t *testing.T) {
-
-	p, err := Int8(1).ToProto(nil)
+	p, err := Int8(1).ToProto(context.TODO())
 	assert.NoError(t, err)
 	assert.Equal(t, p.GetLiteral().GetByte(), int32(1))
 
-	p, err = Int16(1).ToProto(nil)
+	p, err = Int16(1).ToProto(context.TODO())
 	assert.NoError(t, err)
 	assert.Equal(t, p.GetLiteral().GetShort(), int32(1))
 
-	p, err = Int32(1).ToProto(nil)
+	p, err = Int32(1).ToProto(context.TODO())
 	assert.NoError(t, err)
 	assert.Equal(t, p.GetLiteral().GetInteger(), int32(1))
 
-	p, err = Int64(1).ToProto(nil)
+	p, err = Int64(1).ToProto(context.TODO())
 	assert.NoError(t, err)
 	assert.Equal(t, p.GetLiteral().GetLong(), int64(1))
 
-	p, err = Float32(1.0).ToProto(nil)
+	p, err = Float32(1.0).ToProto(context.TODO())
 	assert.NoError(t, err)
 	assert.Equal(t, p.GetLiteral().GetFloat(), float32(1.0))
 
-	p, err = Float64(1.0).ToProto(nil)
+	p, err = Float64(1.0).ToProto(context.TODO())
 	assert.NoError(t, err)
 	assert.Equal(t, p.GetLiteral().GetDouble(), float64(1.0))
 
-	p, err = String("1").ToProto(nil)
+	p, err = String("1").ToProto(context.TODO())
 	assert.NoError(t, err)
 	assert.Equal(t, p.GetLiteral().GetString_(), "1")
 
-	p, err = Boolean(true).ToProto(nil)
+	p, err = Boolean(true).ToProto(context.TODO())
 	assert.NoError(t, err)
 	assert.Equal(t, p.GetLiteral().GetBoolean(), true)
 
-	p, err = Binary([]byte{1}).ToProto(nil)
+	p, err = Binary([]byte{1}).ToProto(context.TODO())
 	assert.NoError(t, err)
 	assert.Equal(t, p.GetLiteral().GetBinary(), []byte{1})
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This patch improves the compile time safety for literals by providing specific interface types. This will make using specific types much easier to use.

This patch adds a number of helper methods for dealing with literals for example `column.StringLit()` or `column.Int8Lit()`. In addition it fixes some longer standing bugs around dealing with nil values.


### Why are the changes needed?
Usability, Safety, Stability

### Does this PR introduce _any_ user-facing change?
Added new methods for using the type interfaces for conversion.


### How was this patch tested?
Added testing.
