### PR TITLE
#52 Support for custom iterators on DataFrame

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,9 +15,7 @@
 
 module github.com/apache/spark-connect-go/v35
 
-go 1.22.0
-
-toolchain go1.23.2
+go 1.23.2
 
 require (
 	github.com/apache/arrow-go/v18 v18.0.0

--- a/internal/tests/integration/dataframe_test.go
+++ b/internal/tests/integration/dataframe_test.go
@@ -1039,3 +1039,24 @@ func TestDataFrame_DFNaFunctions(t *testing.T) {
 
 	assert.Equal(t, "Bob", rows[0].At(2))
 }
+
+func TestDataFrame_RangeIter(t *testing.T) {
+	ctx, spark := connect()
+	df, err := spark.Sql(ctx, "select * from range(10)")
+	assert.NoError(t, err)
+	cnt := 0
+	for row, err := range df.All(ctx) {
+		assert.NoError(t, err)
+		assert.NotNil(t, row)
+		cnt++
+	}
+	assert.Equal(t, 10, cnt)
+
+	// Check that errors are properly propagated
+	df, err = spark.Sql(ctx, "select if(id = 5, raise_error('handle'), false) from range(10)")
+	assert.NoError(t, err)
+	for _, err := range df.All(ctx) {
+		// The error is immediately thrown:
+		assert.Error(t, err)
+	}
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Based on the support for [iterators and ranging ](https://pkg.go.dev/iter@master)over functions in Go 1.23, this patch adds support for such an operator for the DataFrame. 

Following the naming conventions of Golang the new function is called `All(context.Context)` and allows to write the following idiomatic code:

```golang
df, err := spark.Sql(ctx, "select * from range(10)")
if err != nil {
  panic(err)
}
for row, err := range df.All(ctx) {
  // ...
}
```

This avoids calling `Collect(ctx)` and then ranging over the result, but it is semantically equivalent

### Why are the changes needed?
Simplicity

### Does this PR introduce _any_ user-facing change?
Adds new custom range iterator


### How was this patch tested?
Added tests