### PR TITLE
#86 Fix ordering of `Row.FieldNames()`

### DIFF
--- a/spark/sql/types/row.go
+++ b/spark/sql/types/row.go
@@ -16,6 +16,10 @@
 
 package types
 
+import (
+	"maps"
+)
+
 type Row interface {
 	// At returns field's value at the given index within a [Row].
 	// It returns nil for invalid indices.
@@ -59,9 +63,10 @@ func (r *rowImpl) Len() int {
 }
 
 func (r *rowImpl) FieldNames() []string {
-	names := make([]string, 0, len(r.offsets))
-	for name := range r.offsets {
-		names = append(names, name)
+	names := make([]string, len(r.offsets))
+	// Sort the field names to make the output deterministic.
+	for k, v := range maps.All(r.offsets) {
+		names[v] = k
 	}
 	return names
 }

--- a/spark/sql/types/row_test.go
+++ b/spark/sql/types/row_test.go
@@ -26,11 +26,11 @@ import (
 var rowImplSample rowImpl = rowImpl{
 	values: []any{1, 2, 3, 4, 5},
 	offsets: map[string]int{
+		"five":  4,
 		"one":   0,
 		"two":   1,
-		"three": 2,
 		"four":  3,
-		"five":  4,
+		"three": 2,
 	},
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Previously, the map order was used to return the list of field names which is not guaranteed to be stable. This patch implements a stable list based on the offset inside the row schema.

### Why are the changes needed?
Correctness

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing UT