### PR TITLE
#53 Adding support for UserAgent and UserId

### DIFF
--- a/spark/client/channel/channel.go
+++ b/spark/client/channel/channel.go
@@ -24,8 +24,12 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"os"
+	"runtime"
 	"strconv"
 	"strings"
+
+	"github.com/apache/spark-connect-go/v35/spark"
 
 	"github.com/google/uuid"
 
@@ -56,6 +60,9 @@ type Builder interface {
 	// SessionId identifies the client side session identifier. This value must be a UUID formatted
 	// as a string.
 	SessionId() string
+	// UserAgent identifies the user agent string that is passed as part of the request. It contains
+	// information about the operating system, Go version etc.
+	UserAgent() string
 }
 
 // BaseBuilder is used to parse the different parameters of the connection
@@ -69,6 +76,7 @@ type BaseBuilder struct {
 	user      string
 	headers   map[string]string
 	sessionId string
+	userAgent string
 }
 
 func (cb *BaseBuilder) Host() string {
@@ -93,6 +101,10 @@ func (cb *BaseBuilder) Headers() map[string]string {
 
 func (cb *BaseBuilder) SessionId() string {
 	return cb.sessionId
+}
+
+func (cb *BaseBuilder) UserAgent() string {
+	return cb.userAgent
 }
 
 // Build finalizes the creation of the gprc.ClientConn by creating a GRPC channel
@@ -178,6 +190,7 @@ func NewBuilder(connection string) (*BaseBuilder, error) {
 		port:      port,
 		headers:   map[string]string{},
 		sessionId: uuid.NewString(),
+		userAgent: "",
 	}
 
 	elements := strings.Split(u.Path, ";")
@@ -190,10 +203,33 @@ func NewBuilder(connection string) (*BaseBuilder, error) {
 				cb.user = props[1]
 			} else if props[0] == "session_id" {
 				cb.sessionId = props[1]
+			} else if props[0] == "user_agent" {
+				cb.userAgent = props[1]
 			} else {
 				cb.headers[props[0]] = props[1]
 			}
 		}
 	}
+
+	// Set default user ID if not set.
+	if cb.user == "" {
+		cb.user = os.Getenv("USER")
+		if cb.user == "" {
+			cb.user = "na"
+		}
+	}
+
+	// Update the user agent if it is not set or set to a custom value.
+	val := os.Getenv("SPARK_CONNECT_USER_AGENT")
+	if cb.userAgent == "" && val != "" {
+		cb.userAgent = os.Getenv("SPARK_CONNECT_USER_AGENT")
+	} else if cb.userAgent == "" {
+		cb.userAgent = "_SPARK_CONNECT_GO"
+	}
+
+	// In addition, to the specified user agent, we need to append information about the
+	// host encoded as user agent components.
+	cb.userAgent = fmt.Sprintf("%s spark/%s os/%s go/%s", cb.userAgent, spark.Version(), runtime.GOOS, runtime.Version())
+
 	return cb, nil
 }

--- a/spark/client/channel/channel_test.go
+++ b/spark/client/channel/channel_test.go
@@ -96,3 +96,19 @@ func TestChannelBuildConnect(t *testing.T) {
 	assert.Nil(t, err, "no error for proper connection")
 	assert.NotNil(t, conn)
 }
+
+func TestChannelBulder_UserAgent(t *testing.T) {
+	cb, err := channel.NewBuilder("sc://localhost")
+	assert.NoError(t, err)
+	assert.True(t, strings.Contains(cb.UserAgent(), "_SPARK_CONNECT_GO"))
+	assert.True(t, strings.Contains(cb.UserAgent(), "go/"))
+	assert.True(t, strings.Contains(cb.UserAgent(), "spark/"))
+	assert.True(t, strings.Contains(cb.UserAgent(), "os/"))
+
+	cb, err = channel.NewBuilder("sc://localhost/;user_agent=custom")
+	assert.NoError(t, err)
+	assert.True(t, strings.Contains(cb.UserAgent(), "custom"))
+	assert.True(t, strings.Contains(cb.UserAgent(), "go/"))
+	assert.True(t, strings.Contains(cb.UserAgent(), "spark/"))
+	assert.True(t, strings.Contains(cb.UserAgent(), "os/"))
+}

--- a/spark/sql/sparksession.go
+++ b/spark/sql/sparksession.go
@@ -93,9 +93,15 @@ func (s *SparkSessionBuilder) Build(ctx context.Context) (SparkSession, error) {
 	}
 
 	sessionId := uuid.NewString()
+
+	// Update the options according to the configuration.
+	opts := options.NewSparkClientOptions(options.DefaultSparkClientOptions.ReattachExecution)
+	opts.UserAgent = s.channelBuilder.UserAgent()
+	opts.UserId = s.channelBuilder.User()
+
 	return &sparkSessionImpl{
 		sessionId: sessionId,
-		client:    client.NewSparkExecutor(conn, meta, sessionId, options.DefaultSparkClientOptions),
+		client:    client.NewSparkExecutor(conn, meta, sessionId, opts),
 	}, nil
 }
 

--- a/spark/version.go
+++ b/spark/version.go
@@ -5,7 +5,7 @@
 // (the "License"); you may not use this file except in compliance with
 // the License.  You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//    http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,20 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package options
+package spark
 
-type SparkClientOptions struct {
-	ReattachExecution bool
-	UserAgent         string
-	UserId            string
-}
-
-var DefaultSparkClientOptions = SparkClientOptions{
-	ReattachExecution: false,
-}
-
-func NewSparkClientOptions(reattach bool) SparkClientOptions {
-	return SparkClientOptions{
-		ReattachExecution: reattach,
-	}
+func Version() string {
+	return "3.5.x"
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This patch adds proper support for the `user_agent` and `user_id` property of the connection string. In addition, it provides sensible default values for these parameters when connecting from a Go application.

### Why are the changes needed?
Compatibility

### Does this PR introduce _any_ user-facing change?
Compatibility

### How was this patch tested?
Added tests