### PR TITLE
Add Support for Struct Conversion when reading Arrow data

### DIFF
--- a/spark/sql/types/arrow.go
+++ b/spark/sql/types/arrow.go
@@ -260,6 +260,27 @@ func readArrayData(t arrow.Type, data arrow.ArrayData) ([]any, error) {
 			}
 			buf = append(buf, tmp)
 		}
+	case arrow.STRUCT:
+		data := array.NewStructData(data)
+		schema := data.DataType().(*arrow.StructType)
+
+		for i := 0; i < data.Len(); i++ {
+			if data.IsNull(i) {
+				buf = append(buf, nil)
+				continue
+			}
+			tmp := make(map[string]any)
+
+			for j := 0; j < data.NumField(); j++ {
+				field := data.Field(j)
+				fieldValues, err := readArrayData(field.DataType().ID(), field.Data())
+				if err != nil {
+					return nil, err
+				}
+				tmp[schema.Field(j).Name] = fieldValues[i]
+			}
+			buf = append(buf, tmp)
+		}
 	default:
 		return nil, fmt.Errorf("unsupported arrow data type %s", t.String())
 	}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds support for struct conversion when reading Arrow data

### Why are the changes needed?

Resolves #114

### Does this PR introduce _any_ user-facing change?

Additional functionality when reading Arrow data

### How was this patch tested?

By extending existing test case [`TestReadArrowRecord`](https://github.com/apache/spark-connect-go/blob/c00cb58be96046e09d41bba0534eeb0417f46e3c/spark/sql/types/arrow_test.go#L74)