### PR TITLE
[FEAT][INFRA]Improve Merge PR Script

### DIFF
--- a/merge_connect_go_pr.py
+++ b/merge_connect_go_pr.py
@@ -214,11 +214,9 @@ def merge_pr(pr_num, target_ref, title, body, pr_repo_desc):
     data = {
         "commit_title": title,
         "commit_message": merge_message,
+        # Must be squash, always.
         "merge_method": "squash",
     }
-
-    print(data)
-    fail("error here")
 
     continue_maybe("Collected all data. Ready to merge PR?")
     


### PR DESCRIPTION
### What changes were proposed in this pull request?
This patch improves the merge PR script by collecting all authors and the committer who signed of via the script and then prepare the commit message accordingly. Lastly it will squash merge the PR via the Github API and the updated Title and Commit message instead of manually pushing the PR.

### Why are the changes needed?
Better GH integration

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manually using the PRs: #157 #156  #159 and #160.
