### PR TITLE
Add Options for DataFrameWriter

### DIFF
--- a/internal/tests/integration/dataframe_test.go
+++ b/internal/tests/integration/dataframe_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path"
 	"testing"
 
 	"github.com/apache/spark-connect-go/spark/sql/utils"
@@ -803,6 +804,33 @@ func TestDataFrame_WithOption(t *testing.T) {
 	c, err := df.Count(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(10), c)
+}
+
+func TestDataFrame_WriteWithOption(t *testing.T) {
+	ctx, spark := connect()
+	df, err := spark.CreateDataFrame(ctx, [][]any{{1, "a"}, {2, "b"}}, types.StructOf(
+		types.NewStructField("f1-i32", types.INTEGER),
+		types.NewStructField("f2-string", types.STRING)),
+	)
+	require.NoError(t, err)
+	c, err := df.Count(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(2), c)
+	outDir, err := os.MkdirTemp("", "example.out")
+	outfilePath := path.Join(outDir, "example.csv")
+	defer os.RemoveAll(outDir)
+	assert.NoError(t, err)
+	err = df.Writer().Format("csv").
+		Option("header", "true").
+		Save(ctx, outfilePath)
+	assert.NoError(t, err)
+	verifyDf, err := spark.Read().Format("csv").
+		Option("header", "true").
+		Load(outfilePath)
+	assert.NoError(t, err)
+	c, err = verifyDf.Count(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(2), c)
 }
 
 func TestDataFrame_Sample(t *testing.T) {

--- a/internal/tests/integration/dataframe_test.go
+++ b/internal/tests/integration/dataframe_test.go
@@ -812,14 +812,14 @@ func TestDataFrame_WriteWithOption(t *testing.T) {
 		types.NewStructField("f1-i32", types.INTEGER),
 		types.NewStructField("f2-string", types.STRING)),
 	)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	c, err := df.Count(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(2), c)
 	outDir, err := os.MkdirTemp("", "example.out")
+	assert.NoError(t, err)
 	outfilePath := path.Join(outDir, "example.csv")
 	defer os.RemoveAll(outDir)
-	assert.NoError(t, err)
 	err = df.Writer().Format("csv").
 		Option("header", "true").
 		Save(ctx, outfilePath)

--- a/spark/sql/dataframewriter.go
+++ b/spark/sql/dataframewriter.go
@@ -33,12 +33,14 @@ type DataFrameWriter interface {
 	Format(source string) DataFrameWriter
 	// Save writes data frame to the given path.
 	Save(ctx context.Context, path string) error
+	Option(key, value string) DataFrameWriter
 }
 
 func newDataFrameWriter(sparkExecutor *sparkSessionImpl, relation *proto.Relation) DataFrameWriter {
 	return &dataFrameWriterImpl{
 		sparkExecutor: sparkExecutor,
 		relation:      relation,
+		options:       nil,
 	}
 }
 
@@ -48,6 +50,7 @@ type dataFrameWriterImpl struct {
 	relation      *proto.Relation
 	saveMode      string
 	formatSource  string
+	options       map[string]string
 }
 
 func (w *dataFrameWriterImpl) Mode(saveMode string) DataFrameWriter {
@@ -80,6 +83,7 @@ func (w *dataFrameWriterImpl) Save(ctx context.Context, path string) error {
 						SaveType: &proto.WriteOperation_Path{
 							Path: path,
 						},
+						Options: w.options,
 					},
 				},
 			},
@@ -92,6 +96,14 @@ func (w *dataFrameWriterImpl) Save(ctx context.Context, path string) error {
 
 	_, _, err = responseClient.ToTable()
 	return err
+}
+
+func (w *dataFrameWriterImpl) Option(key, value string) DataFrameWriter {
+	if w.options == nil {
+		w.options = make(map[string]string)
+	}
+	w.options[key] = value
+	return w
 }
 
 func getSaveMode(mode string) (proto.WriteOperation_SaveMode, error) {

--- a/spark/sql/dataframewriter_test.go
+++ b/spark/sql/dataframewriter_test.go
@@ -66,6 +66,7 @@ func TestSaveExecutesWriteOperationUntilEOF(t *testing.T) {
 	writer := newDataFrameWriter(session, relation)
 	writer.Format("format")
 	writer.Mode("append")
+	writer.Option("foo", "bar")
 	err := writer.Save(ctx, path)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

- This pipes options through DataFrameWriter into the WriterOperation proto message.


### Why are the changes needed?

- Write options are supported in the API already, this just exposes the ability to set them in golang
- Write options are needed for many output formats, in my specific case Opensearch


### Does this PR introduce _any_ user-facing change?

Yes!

It adds the ability to set options on DataFrameWriter


### How was this patch tested?

Added a call to Option in the unit tests.
Added an integration test for writer options
