### PR TITLE
[BUILD] refer to setup-sbt by hash

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
             /home/runner/deps/spark-${{ env.SPARK_VERSION }}-bin-hadoop${{ env.HADOOP_VERSION }}
 
       - name: Setup SBT
-        uses: sbt/setup-sbt@v1
+        uses: sbt/setup-sbt@3e125ece5c3e5248e18da9ed8d2cce3d335ec8dd # v1.1.14
 
       - name: Setup Apache Spark
         if: steps.cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
### What changes were proposed in this pull request?

Refer to setup-sbt by commit hash

### Why are the changes needed?

To avoid supply chaing attacks where an attacker points the tag to a different, malicious version of the action. This is also required by https://infra.apache.org/github-actions-policy.html