### PR TITLE
[FEAT] Add Dtypes method to DataFrame

### DIFF
--- a/spark/sql/dataframe.go
+++ b/spark/sql/dataframe.go
@@ -102,6 +102,8 @@ type DataFrame interface {
 	Describe(ctx context.Context, cols ...string) DataFrame
 	// Distinct returns a new DataFrame containing the distinct rows in this DataFrame.
 	Distinct(ctx context.Context) DataFrame
+	// Dtypes returns the list of column names and their data types as a list of [name, type] pairs.
+	Dtypes(ctx context.Context) ([][2]string, error)
 	// Drop returns a new DataFrame that drops the specified list of columns.
 	Drop(ctx context.Context, columns ...column.Convertible) (DataFrame, error)
 	// DropByName returns a new DataFrame that drops the specified list of columns by name.
@@ -310,6 +312,18 @@ func (df *dataFrameImpl) Columns(ctx context.Context) ([]string, error) {
 		columns[i] = field.Name
 	}
 	return columns, nil
+}
+
+func (df *dataFrameImpl) Dtypes(ctx context.Context) ([][2]string, error) {
+	schema, err := df.Schema(ctx)
+	if err != nil {
+		return nil, err
+	}
+	dtypes := make([][2]string, len(schema.Fields))
+	for i, field := range schema.Fields {
+		dtypes[i] = [2]string{field.Name, field.DataType.TypeName()}
+	}
+	return dtypes, nil
 }
 
 func (df *dataFrameImpl) Corr(ctx context.Context, col1, col2 string) (float64, error) {


### PR DESCRIPTION
What changes were proposed in this pull request?                                                                                                                                                          
                                                                                                                                                                                                    
This PR adds the Dtypes method to the DataFrame interface and its implementation on dataFrameImpl in the Go Spark Connect client. The method returns column names paired with their data type strings as [][2]string, mirroring PySpark's DataFrame.dtypes property.                                                                                                                                               
 
The implementation reuses the existing Schema() method and follows the same pattern as the already-implemented Columns() method (spark/sql/dataframe.go:303), additionally extracting field.DataType.TypeName() for each field.

This is tracked in the umbrella issue: https://github.com/apache/spark-connect-go/issues/58

Why are the changes needed?

dtypes is a standard DataFrame API in PySpark that returns the list of column names and their data types. It is listed as unimplemented in the DataFrame functionality tracking issue. Adding it improves API parity between the Go Spark Connect client and PySpark, making it easier for users to inspect the schema of a DataFrame in a concise format.

Does this PR introduce any user-facing change?

Yes. A new method Dtypes(ctx context.Context) ([][2]string, error) is added to the public DataFrame interface. Users can now call Dtypes on a DataFrame to get column name and type pairs, for example:

dtypes, err := df.Dtypes(ctx)
// dtypes: [["age", "Integer"], ["name", "String"]]

There is no change to existing behavior.

How was this patch tested?

The implementation is a straightforward extension of the existing Columns() method pattern; it calls Schema() and iterates over the fields. No new unit tests were added because Dtypes depends on Schema() which requires a live Spark session (same as Columns()). The method can be verified via integration tests against a running Spark Connect server.